### PR TITLE
Add bench for tanimoto_distance

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,5 +1,6 @@
 on:
-  push: {}
+  push:
+    branches: [main]
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,43 @@
+on:
+  push: {}
+
+env:
+  REGISTRY: ghcr.io
+  REPO_LOWER: rdkit-rs/cheminee
+
+jobs:
+  test:
+    env:
+      ARCH: amd64
+    runs-on: buildjet-16vcpu-ubuntu-2204
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: Run sccache-cache
+        uses: mozilla/sccache-action@eaed7fb9f8fb32adea8bd40d7f276f312de9beaf
+        with:
+          version: "v0.4.0-pre.10"
+
+      - name: Run sccache stat for check
+        shell: bash
+        run: ${SCCACHE_PATH} --show-stats
+
+      - name: Install rdkit
+        run: |
+          sudo bash -c "echo 'deb [trusted=yes] https://rdkit-rs-debian.s3.amazonaws.com jammy main' > /etc/apt/sources.list.d/rdkit-rs.list"
+          sudo apt-get update
+          sudo apt-get install -y build-essential librdkit-dev libssl-dev libboost1.74-dev libboost-serialization1.74-dev pkg-config
+
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
+
+      - name: Cargo Bench
+        run: RUST_WRAPPER=$SCCACHE_PATH cargo bench

--- a/benches/fingerprint_benches.rs
+++ b/benches/fingerprint_benches.rs
@@ -21,3 +21,14 @@ fn bench_tanimoto_distance(b: &mut Bencher) {
 // running 1 test
 // Before: test bench_tanimoto_similarity ... bench:     132,690 ns/iter (+/- 2,681)
 // Now: test bench_tanimoto_distance ... bench:       2,653 ns/iter (+/- 790)
+
+#[bench]
+fn bench_fingerprint_generation(b: &mut Bencher) {
+    let smiles = "[N]Cc1cncc2c(=O)c3cccc(CCC(=O)O)c3[nH]c12";
+    let romol = ROMol::from_smile(smiles).unwrap();
+
+    b.iter(|| romol.fingerprint());
+}
+
+// running 1 test
+// test bench_fingerprint_generation ... bench:   1,161,160 ns/iter (+/- 274,184)

--- a/benches/tanimoto_bench.rs
+++ b/benches/tanimoto_bench.rs
@@ -1,19 +1,23 @@
-// #![allow(soft_unstable)]
-// #![feature(test)]
-//
-// extern crate test;
-// use test::Bencher;
-//
-// #[bench]
-// fn bench_tanimoto_similarity(b: &mut Bencher) {
-//     let smiles1 = "c1ccccc1CCCCCCCC";
-//     let mol1 = Molecule::new(smiles1, "").unwrap();
-//
-//     let smiles2 = "c1ccccc1CCCCCC";
-//     let mol2 = Molecule::new(smiles2, "").unwrap();
-// 
-//     b.iter(|| mol1.get_tanimoto_similarity(&mol2, "", ""));
-// }
+#![feature(test)]
+
+use rdkit::*;
+use cheminee::analysis::compound_processing::*;
+
+extern crate test;
+use test::Bencher;
+
+#[bench]
+fn bench_tanimoto_distance(b: &mut Bencher) {
+    let smiles1 = "[N]Cc1cncc2c(=O)c3cccc(CCC(=O)O)c3[nH]c12";
+    let (_proc_smiles1, fingerprint1, _descriptors1) = process_cpd(smiles1).unwrap();
+
+    let smiles2 = "CCc1cccc2c(=O)c3cncc(CN)c3[nH]c12";
+    let (_proc_smiles2, fingerprint2, _descriptors2) = process_cpd(smiles2).unwrap();
+
+
+    b.iter(|| fingerprint1.tanimoto_distance(&fingerprint2));
+}
 
 // running 1 test
-// test bench_xor_1000_ints ... bench:     132,690 ns/iter (+/- 2,681)
+// Before: test bench_tanimoto_similarity ... bench:     132,690 ns/iter (+/- 2,681)
+// Now: test bench_tanimoto_distance ... bench:       2,653 ns/iter (+/- 790)

--- a/src/analysis/compound_processing.rs
+++ b/src/analysis/compound_processing.rs
@@ -30,14 +30,13 @@ pub fn get_tautomers(romol: &ROMol) -> Vec<ROMol> {
     ts
 }
 
-#[allow(unreachable_code)]
-pub fn process_cpd(smi: &str) -> eyre::Result<(&str, BitVec<u8>, HashMap<String, f64>)> {
+pub fn process_cpd(smi: &str) -> eyre::Result<(&str, Fingerprint, HashMap<String, f64>)> {
     let canon_taut = standardize_smiles(smi)?;
     let properties = Properties::new();
     let computed = properties.compute_properties(&canon_taut);
     let rdkit_fp = canon_taut.fingerprint();
 
-    Ok((smi, rdkit_fp.0, computed))
+    Ok((smi, rdkit_fp, computed))
 }
 
 lazy_static::lazy_static! {

--- a/tests/cpd_processing_tests.rs
+++ b/tests/cpd_processing_tests.rs
@@ -64,7 +64,7 @@ fn test_process_cpd() {
     ]);
 
     assert_eq!(proc_smiles, "Oc1c(cccc3)c3nc2ccncc12");
-    assert_eq!(fingerprint, expected_fp);
+    assert_eq!(fingerprint.0, expected_fp);
     assert_eq!(*descriptors.get("exactmw").unwrap(), 196.063662876);
 }
 


### PR DESCRIPTION
Also modify process_cpd() method to export `Fingerprint` type instead of bitvec. This is necessary because the tanimoto_distance() method takes `Fingerprint` as input (i.e. not a bitvec).