### PR TITLE
Sccache

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -79,10 +79,6 @@ jobs:
       - name: Docker image size
         run: docker history ${{ steps.meta.outputs.tags }}
 
-      - name: Run sccache stat for check
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
   push:
       runs-on: buildjet-2vcpu-ubuntu-2204
       needs: [build]

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -28,9 +28,7 @@ jobs:
         run: env; echo ARCH=$(uname -m) >> $GITHUB_ENV
 
       - name: Run sccache-cache
-        uses: mozilla/sccache-action@eaed7fb9f8fb32adea8bd40d7f276f312de9beaf
-        with:
-          version: "v0.4.0-pre.10"
+        uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: Run sccache stat for check
         shell: bash

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -6,6 +6,8 @@ on:
 env:
   REGISTRY: ghcr.io
   REPO_LOWER: rdkit-rs/cheminee
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
    build-amd64:

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -6,7 +6,7 @@ env:
   REPO_LOWER: rdkit-rs/cheminee
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
-  RUSTFLAGS: "-C incremental=false"
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   test:

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -6,6 +6,7 @@ env:
   REPO_LOWER: rdkit-rs/cheminee
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
+  RUSTFLAGS: "-C incremental=false"
 
 jobs:
   test:

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -4,6 +4,8 @@ on:
 env:
   REGISTRY: ghcr.io
   REPO_LOWER: rdkit-rs/cheminee
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   test:
@@ -18,9 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run sccache-cache
-        uses: mozilla/sccache-action@eaed7fb9f8fb32adea8bd40d7f276f312de9beaf
-        with:
-          version: "v0.4.0-pre.10"
+        uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: Run sccache stat for check
         shell: bash
@@ -40,4 +40,8 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cargo Test
-        run: RUST_WRAPPER=$SCCACHE_PATH cargo test
+        run: cargo test
+
+      - name: Run sccache stat for check
+        shell: bash
+        run: ${SCCACHE_PATH} --show-stats

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -41,7 +41,3 @@ jobs:
 
       - name: Cargo Test
         run: cargo test
-
-      - name: Run sccache stat for check
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats


### PR DESCRIPTION
rustc is happy to redo work over and over again. but github gives a cubby hole for storing built binaries, let's use it. sccache has the smarts for patching rustc to use the cache.