### PR TITLE
Better Schema + Index Management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
  "poem",
  "poem-openapi",
  "poem-openapi-derive",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "rdkit",
  "regex",
@@ -281,6 +281,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tantivy",
+ "tempdir",
  "tokio",
  "tracing-subscriber",
 ]
@@ -377,7 +378,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "subtle",
  "time",
@@ -474,7 +475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -676,7 +677,7 @@ checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
 dependencies = [
  "log",
  "once_cell",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -743,6 +744,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -1739,13 +1746,26 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1755,8 +1775,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1817,6 +1852,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,6 +1900,15 @@ name = "regex-syntax"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "reqwest"
@@ -2346,6 +2399,16 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ tracing-subscriber = "0.3"
 
 [dev-dependencies]
 env_logger = "0"
+tempdir = "0"

--- a/src/indexing/index_manager.rs
+++ b/src/indexing/index_manager.rs
@@ -26,9 +26,13 @@ impl IndexManager {
         })
     }
 
-    pub fn create(&self, name: &str, schema: Schema, force: bool) -> eyre::Result<tantivy::Index> {
+    pub fn create(&self, name: &str, schema: &Schema, force: bool) -> eyre::Result<tantivy::Index> {
         let builder = IndexBuilder::new().schema(schema.clone());
         let index_path = self.storage_dir.join(name);
+
+        if !index_path.exists() {
+            std::fs::create_dir_all(&index_path)?;
+        }
 
         let index = match builder.create_in_dir(&index_path) {
             Ok(index) => index,
@@ -62,10 +66,28 @@ impl IndexManager {
             Ok(None)
         }
     }
+
+    // Open?
+
+    // Delete?
+
+    // List?
 }
 
-#[cfg(tests)]
+#[cfg(test)]
 mod tests {
+    use crate::indexing::index_manager::IndexManager;
+
     #[test]
-    fn index_manager() {}
+    fn index_manager() -> eyre::Result<()> {
+        let index_manager = IndexManager::new("/tmp/xavier", true)?;
+
+        let schema = crate::schema::LIBRARY.get("descriptor_v1").unwrap();
+
+        let _index = index_manager.create("structure-search", schema, true)?;
+
+        assert!(index_manager.exists("structure-search").unwrap().is_some());
+
+        Ok(())
+    }
 }

--- a/src/indexing/manager.rs
+++ b/src/indexing/manager.rs
@@ -1,0 +1,71 @@
+use std::path::PathBuf;
+use tantivy::directory::MmapDirectory;
+use tantivy::{schema::Schema, IndexBuilder, TantivyError};
+
+pub struct IndexManager {
+    storage_dir: PathBuf,
+}
+
+impl IndexManager {
+    pub fn new<T>(storage_dir: T, create_storage_dir_if_missing: bool) -> eyre::Result<Self>
+    where
+        T: Into<PathBuf>,
+    {
+        let storage_dir = storage_dir.into();
+        if storage_dir.exists() && !storage_dir.is_dir() {
+            return Err(eyre::eyre!(
+                "{:?} exists but it is not a directory",
+                storage_dir
+            ));
+        } else if !storage_dir.exists() && create_storage_dir_if_missing {
+            std::fs::create_dir_all(&storage_dir)?;
+        }
+
+        Ok(Self {
+            storage_dir: storage_dir.into(),
+        })
+    }
+
+    pub fn create(&self, name: &str, schema: Schema, force: bool) -> eyre::Result<tantivy::Index> {
+        let builder = IndexBuilder::new().schema(schema.clone());
+        let index_path = self.storage_dir.join(name);
+
+        let index = match builder.create_in_dir(&index_path) {
+            Ok(index) => index,
+            Err(TantivyError::IndexAlreadyExists) => {
+                if force {
+                    std::fs::remove_dir_all(&index_path)?;
+                    std::fs::create_dir(&index_path)?;
+                    let builder = IndexBuilder::new().schema(schema.clone());
+                    builder.create_in_dir(&index_path)?
+                } else {
+                    return Err(eyre::eyre!(
+                        "index already exists and force reset option not set"
+                    ));
+                }
+            }
+            Err(e) => return Err(eyre::eyre!("unhandled error: {:?}", e)),
+        };
+
+        Ok(index)
+    }
+
+    pub fn exists(&self, name: &str) -> eyre::Result<Option<tantivy::schema::Schema>> {
+        let index_path = self.storage_dir.join(name);
+
+        if index_path.exists() && index_path.is_dir() {
+            let mmap_directory = MmapDirectory::open(index_path)?;
+            let index = tantivy::Index::open(mmap_directory)?;
+
+            Ok(Some(index.schema()))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(tests)]
+mod tests {
+    #[test]
+    fn index_manager() {}
+}

--- a/src/indexing/mod.rs
+++ b/src/indexing/mod.rs
@@ -5,7 +5,7 @@ use tantivy::{Index, IndexBuilder, TantivyError};
 
 pub use tantivy::doc;
 
-pub mod manager;
+pub mod index_manager;
 
 // pub const KNOWN_DESCRIPTORS: [&str; 2] = ["CrippenClogP", "CrippenMR"];
 pub const KNOWN_DESCRIPTORS: [&str; 43] = [

--- a/src/indexing/mod.rs
+++ b/src/indexing/mod.rs
@@ -5,6 +5,8 @@ use tantivy::{Index, IndexBuilder, TantivyError};
 
 pub use tantivy::doc;
 
+pub mod manager;
+
 // pub const KNOWN_DESCRIPTORS: [&str; 2] = ["CrippenClogP", "CrippenMR"];
 pub const KNOWN_DESCRIPTORS: [&str; 43] = [
     "CrippenClogP",

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,6 +1,6 @@
 use crate::indexing::KNOWN_DESCRIPTORS;
 use std::collections::HashMap;
-use tantivy::schema::{Schema, SchemaBuilder, FAST, STORED, TEXT};
+use tantivy::schema::{JsonObjectOptions, Schema, SchemaBuilder, FAST, STORED, TEXT};
 
 lazy_static::lazy_static! {
     pub static ref LIBRARY: HashMap<&'static str, tantivy::schema::Schema> = [("descriptor_v1", descriptor_v1_schema())].into_iter().collect();
@@ -19,7 +19,9 @@ fn descriptor_v1_schema() -> Schema {
     }
     builder.add_bytes_field("fingerprint", FAST | STORED);
 
-    builder.add_json_field("extra_data", STORED);
+    let json_options: JsonObjectOptions =
+        JsonObjectOptions::from(TEXT | STORED).set_expand_dots_enabled();
+    builder.add_json_field("extra_data", json_options);
 
     builder.build()
 }

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -20,7 +20,6 @@ fn descriptor_v1_schema() -> Schema {
     builder.add_bytes_field("fingerprint", FAST | STORED);
 
     builder.add_json_field("extra_data", STORED);
-    builder.add_i64_field("extra_data_org_ids", FAST);
 
     builder.build()
 }

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -19,5 +19,8 @@ fn descriptor_v1_schema() -> Schema {
     }
     builder.add_bytes_field("fingerprint", FAST | STORED);
 
+    builder.add_json_field("extra_data", STORED);
+    builder.add_i64_field("extra_data_org_ids", FAST);
+
     builder.build()
 }

--- a/tests/index_management_tests.rs
+++ b/tests/index_management_tests.rs
@@ -1,4 +1,4 @@
-use cheminee::indexing::manager::IndexManager;
+use cheminee::indexing::index_manager::IndexManager;
 
 #[test]
 fn test_index_management() -> eyre::Result<()> {

--- a/tests/index_management_tests.rs
+++ b/tests/index_management_tests.rs
@@ -1,0 +1,11 @@
+use cheminee::indexing::manager::IndexManager;
+
+#[test]
+fn test_index_management() -> eyre::Result<()> {
+    let temp_index_dir = tempdir::TempDir::new("/tmp")?;
+    let manager = IndexManager::new(temp_index_dir.path(), true)?;
+
+    assert!(manager.exists("foo")?.is_none());
+
+    Ok(())
+}

--- a/tests/user_data_indexing_tests.rs
+++ b/tests/user_data_indexing_tests.rs
@@ -1,0 +1,41 @@
+use tantivy::schema::{JsonObjectOptions, STORED, TEXT};
+
+#[test]
+fn test_json_data() {
+    let mut schema_builder = tantivy::schema::SchemaBuilder::new();
+    let json_options: JsonObjectOptions =
+        JsonObjectOptions::from(TEXT | STORED).set_expand_dots_enabled();
+    let extra_data = schema_builder.add_json_field("extra_data", json_options);
+    let schema = schema_builder.build();
+
+    let index = tantivy::IndexBuilder::new()
+        .schema(schema)
+        .create_in_ram()
+        .unwrap();
+    let mut writer = index.writer(3 * 1024 * 1024).unwrap();
+    let doc_1 = tantivy::doc!(
+        extra_data => serde_json::from_str::<serde_json::Value>(r#"{"org_ids": [1,2,3]}"#).unwrap()
+    );
+    writer.add_document(doc_1.clone()).unwrap();
+    let doc_2 = tantivy::doc!(
+        extra_data => serde_json::from_str::<serde_json::Value>(r#"{"org_ids": [3,4,5]}"#).unwrap()
+    );
+    writer.add_document(doc_2.clone()).unwrap();
+    writer.commit().unwrap();
+
+    let searcher = index.reader().unwrap().searcher();
+    let query_parser = tantivy::query::QueryParser::for_index(&index, vec![extra_data]);
+    let collector = tantivy::collector::TopDocs::with_limit(100);
+
+    let query = query_parser.parse_query("extra_data.org_ids:2").unwrap();
+    let results = searcher.search(&query, &collector).unwrap();
+    assert_eq!(results.len(), 1);
+    let retrieved_doc = searcher.doc(results[0].1).unwrap();
+    assert_eq!(retrieved_doc, doc_1);
+
+    let query = query_parser.parse_query("extra_data.org_ids:5").unwrap();
+    let results = searcher.search(&query, &collector).unwrap();
+    assert_eq!(results.len(), 1);
+    let retrieved_doc = searcher.doc(results[0].1).unwrap();
+    assert_eq!(retrieved_doc, doc_2);
+}

--- a/tests/user_data_indexing_tests.rs
+++ b/tests/user_data_indexing_tests.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use tantivy::schema::{JsonObjectOptions, STORED, TEXT};
 
 #[test]
@@ -38,4 +39,16 @@ fn test_json_data() {
     assert_eq!(results.len(), 1);
     let retrieved_doc = searcher.doc(results[0].1).unwrap();
     assert_eq!(retrieved_doc, doc_2);
+
+    let query = query_parser.parse_query("extra_data.org_ids:3").unwrap();
+    let results = searcher.search(&query, &collector).unwrap();
+    assert_eq!(results.len(), 2);
+
+    let set = results
+        .into_iter()
+        .map(|(_, doc_id)| serde_json::to_string(&searcher.doc(doc_id).unwrap()).unwrap())
+        .collect::<HashSet<_>>();
+
+    assert!(set.contains(&serde_json::to_string(&doc_1).unwrap()));
+    assert!(set.contains(&serde_json::to_string(&doc_2).unwrap()));
 }


### PR DESCRIPTION
We need to track extra user-submitted free-form JSON for search (namely, database IDs to use in filtering out unwanted structures). Now we can query it, see the attached test case as an example of how to build the JSON schema.

 - [X] Test case proving JSON can store IDs and index/query them
 - [x] Amend descriptor schema v1 to have a similar JSON field