### PR TITLE
OpenAPI Skeleton for Substructure Search and OpenAPI architecture rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /tmp
 .idea/*
 cheminee.iml
+openapi.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,6 @@ version = "0.1.4"
 dependencies = [
  "bitvec",
  "clap",
- "env_logger",
  "eyre",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 tantivy = "0.20.2"
 tokio = { version = "1", features = ["full"] }
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-env_logger = "0"
 tempdir = "0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,19 @@ use clap::*;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "info,poem=debug");
+    if let Some(rust_debug) = std::env::var_os("RUST_DEBUG") {
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                rust_debug
+                    .to_str()
+                    .ok_or(eyre::eyre!("could not convert RUST_DEBUG to str"))?,
+            )
+            .init();
+    } else {
+        tracing_subscriber::fmt()
+            .with_env_filter("poem=info,tokio-runtime-worker=debug")
+            .init();
     }
-    tracing_subscriber::fmt::init();
 
     let app = Command::new("cheminee")
         .subcommand_required(true)

--- a/src/rest_api/api/index_management.rs
+++ b/src/rest_api/api/index_management.rs
@@ -1,6 +1,6 @@
 use poem_openapi::{payload::Json, ApiResponse, Object};
 
-use crate::schema::LIBRARY;
+use crate::{indexing::index_manager::IndexManager, schema::LIBRARY};
 
 #[derive(ApiResponse)]
 pub enum ListSchemasResponse {
@@ -47,7 +47,7 @@ pub struct IndexMeta {
     pub name: String,
 }
 
-pub async fn list_schemas() -> ListSchemasResponse {
+pub async fn v1_list_schemas() -> ListSchemasResponse {
     let schema_descriptions = LIBRARY
         .iter()
         .map(|(name, schema)| Schema {
@@ -57,4 +57,33 @@ pub async fn list_schemas() -> ListSchemasResponse {
         .collect();
 
     ListSchemasResponse::Ok(Json(schema_descriptions))
+}
+
+pub fn v1_list_indexes(index_manager: &IndexManager) -> ListIndexesResponse {
+    let list_result = index_manager.list();
+    if let Err(e) = list_result {
+        return ListIndexesResponse::Err(Json(ListIndexResponseErr {
+            error: format!("{:?}", e),
+        }));
+    }
+
+    let index_metas = list_result
+        .unwrap()
+        .into_iter()
+        .map(|x| IndexMeta { name: x })
+        .collect();
+
+    ListIndexesResponse::Ok(Json(index_metas))
+}
+
+#[allow(unused_variables)]
+pub fn v1_get_index(index_manager: &IndexManager, index: String) -> GetIndexesResponse {
+    let index = index_manager.open(&index);
+
+    match index {
+        Ok(index) => GetIndexesResponse::Ok(Json(vec![])),
+        Err(e) => GetIndexesResponse::Err(Json(GetIndexesResponseError {
+            error: format!("{}", e),
+        })),
+    }
 }

--- a/src/rest_api/api/index_management.rs
+++ b/src/rest_api/api/index_management.rs
@@ -31,6 +31,15 @@ pub struct ListIndexResponseErr {
 pub enum GetIndexesResponse {
     #[oai(status = "200")]
     Ok(Json<Vec<IndexMeta>>),
+    #[oai(status = "400")]
+    NotFound,
+    #[oai(status = "500")]
+    Err(Json<GetIndexesResponseError>),
+}
+
+#[derive(Object)]
+pub struct GetIndexesResponseError {
+    pub error: String,
 }
 
 #[derive(Object, Debug)]
@@ -48,9 +57,4 @@ pub async fn list_schemas() -> ListSchemasResponse {
         .collect();
 
     ListSchemasResponse::Ok(Json(schema_descriptions))
-}
-
-pub async fn list_indexes() -> ListIndexesResponse {
-    // ListSchemasResponse::Ok(Json(vec![]))
-    unimplemented!("bang")
 }

--- a/src/rest_api/api/index_management.rs
+++ b/src/rest_api/api/index_management.rs
@@ -52,7 +52,7 @@ pub async fn list_schemas() -> ListSchemasResponse {
         .iter()
         .map(|(name, schema)| Schema {
             name: name.to_string(),
-            schema: serde_json::to_value(&schema).unwrap(),
+            schema: serde_json::to_value(schema).unwrap(),
         })
         .collect();
 

--- a/src/rest_api/api/mod.rs
+++ b/src/rest_api/api/mod.rs
@@ -1,2 +1,5 @@
 pub mod index_management;
+
+pub mod search;
+
 pub mod standardize;

--- a/src/rest_api/api/mod.rs
+++ b/src/rest_api/api/mod.rs
@@ -1,5 +1,8 @@
-pub mod index_management;
+mod index_management;
+pub use index_management::*;
 
-pub mod search;
+mod search;
+pub use search::*;
 
-pub mod standardize;
+mod standardize;
+pub use standardize::*;

--- a/src/rest_api/api/search/mod.rs
+++ b/src/rest_api/api/search/mod.rs
@@ -1,0 +1,1 @@
+pub mod substructure_search;

--- a/src/rest_api/api/search/mod.rs
+++ b/src/rest_api/api/search/mod.rs
@@ -1,1 +1,2 @@
-pub mod substructure_search;
+mod substructure_search;
+pub use substructure_search::*;

--- a/src/rest_api/api/search/substructure_search.rs
+++ b/src/rest_api/api/search/substructure_search.rs
@@ -12,4 +12,20 @@ pub struct SubstructureSearchHit {
     pub extra_data: serde_json::Value,
     pub smiles: String,
     pub score: f32,
+    pub query: String,
+}
+
+pub fn v1_index_search_substructure(
+    index: String,
+    q: Option<String>,
+) -> GetSubstructureSearchResponse {
+    let q_str = format!("{:?}", q);
+    let index = index.to_string();
+
+    GetSubstructureSearchResponse::Ok(Json(vec![SubstructureSearchHit {
+        extra_data: serde_json::json!({"hi": "mom", "index": index}),
+        smiles: ":)".to_string(),
+        score: 100.00,
+        query: q_str,
+    }]))
 }

--- a/src/rest_api/api/search/substructure_search.rs
+++ b/src/rest_api/api/search/substructure_search.rs
@@ -1,0 +1,15 @@
+use poem_openapi::payload::Json;
+use poem_openapi_derive::{ApiResponse, Object};
+
+#[derive(ApiResponse)]
+pub enum GetSubstructureSearchResponse {
+    #[oai(status = "200")]
+    Ok(Json<Vec<SubstructureSearchHit>>),
+}
+
+#[derive(Object)]
+pub struct SubstructureSearchHit {
+    pub extra_data: serde_json::Value,
+    pub smiles: String,
+    pub score: f32,
+}

--- a/src/rest_api/api/standardize.rs
+++ b/src/rest_api/api/standardize.rs
@@ -9,7 +9,7 @@ mod tests {
     use tokio::sync::Mutex;
 
     use super::*;
-    use crate::{indexing::index_manager::IndexManager, rest_api::Api};
+    use crate::{indexing::index_manager::IndexManager, rest_api::openapi_server::Api};
 
     #[handler]
     async fn index() -> StandardizeResponse {

--- a/src/rest_api/api/standardize.rs
+++ b/src/rest_api/api/standardize.rs
@@ -61,7 +61,7 @@ pub struct StandardizedSmile {
     pub error: Option<String>,
 }
 
-pub async fn standardize(mol: Json<Vec<Smile>>) -> StandardizeResponse {
+pub async fn v1_standardize(mol: Json<Vec<Smile>>) -> StandardizeResponse {
     let standardized_smiles = mol
         .0
         .into_par_iter()

--- a/src/rest_api/api/standardize.rs
+++ b/src/rest_api/api/standardize.rs
@@ -6,16 +6,21 @@ use crate::{rest_api::models::Smile, search::compound_processing::standardize_sm
 #[cfg(test)]
 mod tests {
     use poem::{handler, Route};
+    use tokio::sync::Mutex;
 
     use super::*;
-    use crate::rest_api::Api;
+    use crate::{indexing::index_manager::IndexManager, rest_api::Api};
 
     #[handler]
     async fn index() -> StandardizeResponse {
         let smiles = Json(vec![Smile {
             smile: "CC=CO".to_string(), // smile:  "CCC=O".to_string(), -answer
         }]);
-        Api.v1_standardize(smiles).await
+        Api {
+            index_manager: Mutex::new(IndexManager::new("/tmp/blah", false).unwrap()),
+        }
+        .v1_standardize(smiles)
+        .await
     }
 
     #[tokio::test]
@@ -39,10 +44,6 @@ mod tests {
             .expect("first_value")
             .assert_string("CCC=O");
         println!("{:?}", json_value);
-        // TestJsonValue(Array([Object({"smile": String("CCC=O")})]))
-        //     resp.assert_text("CCC=O").await;
-
-        println!("lllla")
     }
 }
 

--- a/src/rest_api/mod.rs
+++ b/src/rest_api/mod.rs
@@ -3,17 +3,6 @@ pub mod models;
 pub mod openapi_server;
 
 use clap::{Arg, ArgAction};
-use models::Smile;
-use poem_openapi::{param::Path, payload::Json, OpenApi};
-use tokio::sync::Mutex;
-
-use crate::{
-    indexing::index_manager::IndexManager,
-    rest_api::api::{
-        index_management::{GetIndexesResponseError, IndexMeta, ListIndexResponseErr},
-        search::substructure_search::SubstructureSearchHit,
-    },
-};
 
 pub const NAME: &str = "rest-api-server";
 pub fn command() -> clap::Command {
@@ -35,75 +24,6 @@ pub fn command() -> clap::Command {
                 .num_args(1),
         ),
     )
-}
-
-pub struct Api {
-    index_manager: Mutex<IndexManager>,
-}
-
-#[OpenApi]
-impl Api {
-    #[oai(path = "/v1/standardize", method = "post")]
-    async fn v1_standardize(&self, mol: Json<Vec<Smile>>) -> api::standardize::StandardizeResponse {
-        api::standardize::standardize(mol).await
-    }
-
-    #[oai(path = "/v1/schemas", method = "get")]
-    async fn v1_list_schemas(&self) -> api::index_management::ListSchemasResponse {
-        api::index_management::list_schemas().await
-    }
-
-    #[oai(path = "/v1/indexes", method = "get")]
-    async fn v1_list_indexes(&self) -> api::index_management::ListIndexesResponse {
-        let manager = self.index_manager.lock().await;
-
-        let list_result = manager.list();
-        if let Err(e) = list_result {
-            return api::index_management::ListIndexesResponse::Err(Json(ListIndexResponseErr {
-                error: format!("{:?}", e),
-            }));
-        }
-
-        let index_metas = list_result
-            .unwrap()
-            .into_iter()
-            .map(|x| IndexMeta { name: x })
-            .collect();
-
-        api::index_management::ListIndexesResponse::Ok(Json(index_metas))
-    }
-
-    #[oai(path = "/v1/indexes/:index", method = "get")]
-    #[allow(unused_variables)]
-    async fn v1_get_index(&self, index: Path<String>) -> api::index_management::GetIndexesResponse {
-        let index_manager = self.index_manager.lock().await;
-        let index = index_manager.open(&index);
-
-        match index {
-            Ok(index) => api::index_management::GetIndexesResponse::Ok(Json(vec![])),
-            Err(e) => {
-                api::index_management::GetIndexesResponse::Err(Json(GetIndexesResponseError {
-                    error: format!("{}", e),
-                }))
-            }
-        }
-    }
-
-    // v1/indexes/inventory_items_v1/search/substructure?q=1234
-    #[oai(path = "/v1/indexes/:index/search/substructure", method = "get")]
-    #[allow(unused_variables)]
-    async fn v1_index_search_substructure(
-        &self,
-        index: Path<String>,
-    ) -> api::search::substructure_search::GetSubstructureSearchResponse {
-        api::search::substructure_search::GetSubstructureSearchResponse::Ok(Json(vec![
-            SubstructureSearchHit {
-                extra_data: serde_json::json!({"hi": "mom", "index": index.to_string()}),
-                smiles: ":)".to_string(),
-                score: 100.00,
-            },
-        ]))
-    }
 }
 
 fn output_spec(server_url: &str, output: &str) -> eyre::Result<()> {

--- a/src/rest_api/mod.rs
+++ b/src/rest_api/mod.rs
@@ -9,7 +9,10 @@ use tokio::sync::Mutex;
 
 use crate::{
     indexing::index_manager::IndexManager,
-    rest_api::api::index_management::{IndexMeta, ListIndexResponseErr},
+    rest_api::api::{
+        index_management::{IndexMeta, ListIndexResponseErr},
+        search::substructure_search::SubstructureSearchHit,
+    },
 };
 
 pub const NAME: &str = "rest-api-server";
@@ -70,10 +73,25 @@ impl Api {
         api::index_management::ListIndexesResponse::Ok(Json(index_metas))
     }
 
-    #[oai(path = "/v1/indexes/:index", method = "get")]
+    // #[oai(path = "/v1/indexes/:index", method = "get")]
+    // #[allow(unused_variables)]
+    // async fn v1_get_index(&self, index: Path<String>) -> api::index_management::GetIndexesResponse {
+    //     unimplemented!()
+    // }
+
+    // v1/indexes/inventory_items_v1/search/substructure?q=1234
+    #[oai(path = "/v1/indexes/search/substructure", method = "get")]
     #[allow(unused_variables)]
-    async fn v1_get_index(&self, index: Path<String>) -> api::index_management::GetIndexesResponse {
-        unimplemented!()
+    async fn v1_index_search_substructure(
+        &self,
+    ) -> api::search::substructure_search::GetSubstructureSearchResponse {
+        api::search::substructure_search::GetSubstructureSearchResponse::Ok(Json(vec![
+            SubstructureSearchHit {
+                extra_data: serde_json::json!({"hi": "mom"}),
+                smiles: ":)".to_string(),
+                score: 100.00,
+            },
+        ]))
     }
 }
 
@@ -97,7 +115,7 @@ pub async fn action(matches: &clap::ArgMatches) -> eyre::Result<()> {
                 matches.get_one("index-storage-directory").unwrap();
             let index_storage_directory_create_if_missing: bool =
                 matches.get_flag("index-storage-directory-create-if-missing");
-            panic!("create if missing: {}", index_storage_directory);
+
             server::run_api_service(
                 bind,
                 server_url,

--- a/src/rest_api/openapi_server.rs
+++ b/src/rest_api/openapi_server.rs
@@ -1,10 +1,21 @@
 use std::path::PathBuf;
 
 use poem::{listener::TcpListener, Route, Server};
-use poem_openapi::{ContactObject, OpenApiService};
+use poem_openapi::{param::Path, payload::Json, ContactObject, OpenApiService};
+use poem_openapi_derive::OpenApi;
 use tokio::sync::Mutex;
 
-use crate::{indexing::index_manager::IndexManager, rest_api::Api};
+use crate::{
+    indexing::index_manager::IndexManager,
+    rest_api::{
+        api,
+        api::{
+            index_management::{GetIndexesResponseError, IndexMeta, ListIndexResponseErr},
+            search::substructure_search::SubstructureSearchHit,
+        },
+        models::Smile,
+    },
+};
 
 pub fn api_service(
     server_url: &str,
@@ -47,4 +58,73 @@ pub async fn run_api_service(
         .await?;
 
     Ok(())
+}
+
+pub struct Api {
+    index_manager: Mutex<IndexManager>,
+}
+
+#[OpenApi]
+impl Api {
+    #[oai(path = "/v1/standardize", method = "post")]
+    async fn v1_standardize(&self, mol: Json<Vec<Smile>>) -> api::standardize::StandardizeResponse {
+        api::standardize::standardize(mol).await
+    }
+
+    #[oai(path = "/v1/schemas", method = "get")]
+    async fn v1_list_schemas(&self) -> api::index_management::ListSchemasResponse {
+        api::index_management::list_schemas().await
+    }
+
+    #[oai(path = "/v1/indexes", method = "get")]
+    async fn v1_list_indexes(&self) -> api::index_management::ListIndexesResponse {
+        let manager = self.index_manager.lock().await;
+
+        let list_result = manager.list();
+        if let Err(e) = list_result {
+            return api::index_management::ListIndexesResponse::Err(Json(ListIndexResponseErr {
+                error: format!("{:?}", e),
+            }));
+        }
+
+        let index_metas = list_result
+            .unwrap()
+            .into_iter()
+            .map(|x| IndexMeta { name: x })
+            .collect();
+
+        api::index_management::ListIndexesResponse::Ok(Json(index_metas))
+    }
+
+    #[oai(path = "/v1/indexes/:index", method = "get")]
+    #[allow(unused_variables)]
+    async fn v1_get_index(&self, index: Path<String>) -> api::index_management::GetIndexesResponse {
+        let index_manager = self.index_manager.lock().await;
+        let index = index_manager.open(&index);
+
+        match index {
+            Ok(index) => api::index_management::GetIndexesResponse::Ok(Json(vec![])),
+            Err(e) => {
+                api::index_management::GetIndexesResponse::Err(Json(GetIndexesResponseError {
+                    error: format!("{}", e),
+                }))
+            }
+        }
+    }
+
+    // v1/indexes/inventory_items_v1/search/substructure?q=1234
+    #[oai(path = "/v1/indexes/:index/search/substructure", method = "get")]
+    #[allow(unused_variables)]
+    async fn v1_index_search_substructure(
+        &self,
+        index: Path<String>,
+    ) -> api::search::substructure_search::GetSubstructureSearchResponse {
+        api::search::substructure_search::GetSubstructureSearchResponse::Ok(Json(vec![
+            SubstructureSearchHit {
+                extra_data: serde_json::json!({"hi": "mom", "index": index.to_string()}),
+                smiles: ":)".to_string(),
+                score: 100.00,
+            },
+        ]))
+    }
 }

--- a/src/rest_api/openapi_server.rs
+++ b/src/rest_api/openapi_server.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
 
-use poem::{listener::TcpListener, EndpointExt, Route, Server};
+use poem::{listener::TcpListener, Route, Server};
 use poem_openapi::{ContactObject, OpenApiService};
-use tantivy::Index;
 use tokio::sync::Mutex;
 
 use crate::{indexing::index_manager::IndexManager, rest_api::Api};

--- a/tests/cpd_processing_tests.rs
+++ b/tests/cpd_processing_tests.rs
@@ -29,7 +29,7 @@ fn test_standardize_smiles() {
 
 #[test]
 fn test_standardize_bad_smiles() {
-    env_logger::init();
+    tracing_subscriber::fmt().with_env_filter("trace").init();
 
     let smiles = "smiles";
     assert!(standardize_smiles(smiles).is_err());


### PR DESCRIPTION
 * Substructure search is now an official endpoint
 * Move all implementations for endpoints out to their respective modules and made the `derive(OpenAPI)` struct very simple
 * Improve support for tracing subscriber so we can see more logs