### PR TITLE
Actually use tautomer limit...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cheminee"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bitvec",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cheminee"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "Molecule indexing and search"
 license = "MIT"

--- a/src/rest_api/api/search/substructure_search.rs
+++ b/src/rest_api/api/search/substructure_search.rs
@@ -65,13 +65,17 @@ pub fn v1_index_search_substructure(
         }
     };
 
-    let mut tautomers_used = false;
+    let mut used_tautomers = false;
+    let mut num_tauts_used = 0;
+    if results.len() > 0 {
+        num_tauts_used = 1;
+    }
 
     if results.len() < result_limit {
         let tautomers = get_tautomers(&query_canon_taut);
 
         if tautomers.len() > 1 && tautomer_limit > 1 {
-            for test_taut in tautomers.into_iter().take(tautomer_limit) {
+            for test_taut in tautomers {
                 // don't reuse the canonical tautomer
                 if test_taut.as_smile() == query_canon_taut.as_smile() {
                     continue;
@@ -99,20 +103,21 @@ pub fn v1_index_search_substructure(
                     Err(_) => continue,
                 };
 
-                if taut_results.len() > 0 {
-                    tautomers_used = true;
-                };
-
                 results.extend(&taut_results);
+                num_tauts_used += 1;
 
-                if results.len() > result_limit {
+                if used_tautomers == false {
+                    used_tautomers = true;
+                }
+
+                if results.len() > result_limit || num_tauts_used == tautomer_limit {
                     break;
                 }
             }
         }
     }
 
-    let final_results = aggregate_search_hits(searcher, results, tautomers_used, &smile);
+    let final_results = aggregate_search_hits(searcher, results, used_tautomers, &smile);
 
     let final_results = match final_results {
         Ok(final_results) => final_results,

--- a/src/rest_api/api/search/substructure_search.rs
+++ b/src/rest_api/api/search/substructure_search.rs
@@ -70,10 +70,8 @@ pub fn v1_index_search_substructure(
     if results.len() < result_limit {
         let tautomers = get_tautomers(&query_canon_taut);
 
-        if tautomers.len() > 1 && tautomer_limit > 0 {
-            let max_tauts = 10;
-
-            for test_taut in tautomers.into_iter().take(max_tauts) {
+        if tautomers.len() > 1 && tautomer_limit > 1 {
+            for test_taut in tautomers.into_iter().take(tautomer_limit) {
                 // don't reuse the canonical tautomer
                 if test_taut.as_smile() == query_canon_taut.as_smile() {
                     continue;


### PR DESCRIPTION
Previous [PR](https://github.com/rdkit-rs/cheminee/pull/54) that introduced tautomer limit only used that limit to determine whether tautomers should be used. It did not actually use the tautomer limit to limit the number of tautomers used.