### PR TITLE
Basic and substructure search refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,6 +1845,8 @@ dependencies = [
 [[package]]
 name = "rdkit"
 version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea0a8e4d088d0d055523289556e5b7e220984348a7cdca148dfcf9fd7d75661"
 dependencies = [
  "bitvec",
  "byteorder",
@@ -1858,6 +1860,8 @@ dependencies = [
 [[package]]
 name = "rdkit-sys"
 version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fcb3a26e7bde365a818646a50230d65f6703403ac467eb9066ac70d2f18ea7"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ poem-openapi = { version="2", features=["swagger-ui"] }
 poem-openapi-derive = "2"
 rand = "0.8.5"
 rayon = "1"
-rdkit = { version = "0.4.0", path = "../rdkit" }
+rdkit = { version = "0.4.0" }
 regex = "1"
 reqwest = "0"
 serde = { version = "1", features = ["derive"] }

--- a/src/command_line/basic_search.rs
+++ b/src/command_line/basic_search.rs
@@ -1,4 +1,5 @@
 pub use super::prelude::*;
+use crate::search::aggregate_query_hits;
 use crate::search::basic_search::basic_search;
 
 pub const NAME: &str = "search";
@@ -43,9 +44,11 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
     let reader = index.reader()?;
     let searcher = reader.searcher();
 
-    let results = basic_search(&searcher, query, limit);
+    let results = basic_search(&searcher, query, limit)?;
 
-    println!("{:#?}", results);
+    let final_results = aggregate_query_hits(searcher, results, query)?;
+
+    println!("{:#?}", final_results);
 
     Ok(())
 }

--- a/src/command_line/basic_search.rs
+++ b/src/command_line/basic_search.rs
@@ -33,15 +33,15 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
     let query = matches.get_one::<String>("query").unwrap();
     let limit = matches.get_one::<String>("limit");
 
-    let index = open_index(index_path)?;
-    let reader = index.reader()?;
-    let searcher = reader.searcher();
-
     let limit = if let Some(limit) = limit {
         limit.parse::<usize>()?
     } else {
-        usize::try_from(1000).unwrap()
+        usize::try_from(1000)?
     };
+
+    let index = open_index(index_path)?;
+    let reader = index.reader()?;
+    let searcher = reader.searcher();
 
     let results = basic_search(&searcher, query, limit);
 

--- a/src/command_line/substructure_search.rs
+++ b/src/command_line/substructure_search.rs
@@ -37,17 +37,10 @@ pub fn command() -> Command {
                 .num_args(1),
         )
         .arg(
-            Arg::new("exactmw_min")
+            Arg::new("extra_query")
                 .required(false)
-                .long("exactmw_min")
-                .short('n')
-                .num_args(1),
-        )
-        .arg(
-            Arg::new("exactmw_max")
-                .required(false)
-                .long("exactmw_max")
-                .short('x')
+                .long("extra_query")
+                .short('e')
                 .num_args(1),
         )
 }
@@ -57,8 +50,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
     let smile = matches.get_one::<String>("smiles").unwrap();
     let result_limit = matches.get_one::<String>("result_limit");
     let tautomer_limit = matches.get_one::<String>("tautomer_limit");
-    let exactmw_min = matches.get_one::<String>("exactmw_min");
-    let exactmw_max = matches.get_one::<String>("exactmw_max");
+    let extra_query = matches.get_one::<String>("extra_query");
 
     let result_limit = if let Some(result_limit) = result_limit {
         result_limit.parse::<usize>()?
@@ -72,16 +64,10 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         usize::try_from(10)?
     };
 
-    let exactmw_min = if let Some(exactmw_min) = exactmw_min {
-        exactmw_min.parse::<usize>()?
+    let extra_query = if let Some(extra_query) = extra_query {
+        extra_query.clone()
     } else {
-        usize::try_from(0)?
-    };
-
-    let exactmw_max = if let Some(exactmw_max) = exactmw_max {
-        exactmw_max.parse::<usize>()?
-    } else {
-        usize::try_from(10000)?
+        "".to_string()
     };
 
     let index = open_index(index_path)?;
@@ -96,8 +82,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         fingerprint.0.as_bitslice(),
         &descriptors,
         result_limit,
-        exactmw_min,
-        exactmw_max,
+        &extra_query,
     )?;
 
     let mut used_tautomers = false;
@@ -131,8 +116,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
                     taut_fingerprint.0.as_bitslice(),
                     &taut_descriptors,
                     result_limit,
-                    exactmw_min,
-                    exactmw_max,
+                    &extra_query,
                 );
 
                 let taut_results = match taut_results {

--- a/src/command_line/substructure_search.rs
+++ b/src/command_line/substructure_search.rs
@@ -23,10 +23,17 @@ pub fn command() -> Command {
                 .num_args(1),
         )
         .arg(
-            Arg::new("limit")
+            Arg::new("result_limit")
                 .required(false)
-                .long("limit")
-                .short('l')
+                .long("result_limit")
+                .short('r')
+                .num_args(1),
+        )
+        .arg(
+            Arg::new("tautomer_limit")
+                .required(false)
+                .long("tautomer_limit")
+                .short('t')
                 .num_args(1),
         )
 }
@@ -34,13 +41,8 @@ pub fn command() -> Command {
 pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
     let index_path = matches.get_one::<String>("index").unwrap();
     let smile = matches.get_one::<String>("smiles").unwrap();
-    let result_limit = matches.get_one::<String>("limit");
-
-    let (query_canon_taut, fingerprint, descriptors) = prepare_query_structure(smile)?;
-
-    let index = open_index(index_path)?;
-    let reader = index.reader()?;
-    let searcher = reader.searcher();
+    let result_limit = matches.get_one::<String>("result_limit");
+    let tautomer_limit = matches.get_one::<String>("tautomer_limit");
 
     let result_limit = if let Some(result_limit) = result_limit {
         result_limit.parse::<usize>()?
@@ -48,7 +50,17 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         usize::try_from(1000)?
     };
 
-    let tautomer_limit = result_limit * 10;
+    let tautomer_limit = if let Some(tautomer_limit) = tautomer_limit {
+        tautomer_limit.parse::<usize>()?
+    } else {
+        usize::try_from(10)?
+    };
+
+    let index = open_index(index_path)?;
+    let reader = index.reader()?;
+    let searcher = reader.searcher();
+
+    let (query_canon_taut, fingerprint, descriptors) = prepare_query_structure(smile)?;
 
     let mut results = substructure_search(
         &searcher,

--- a/src/command_line/substructure_search.rs
+++ b/src/command_line/substructure_search.rs
@@ -36,6 +36,20 @@ pub fn command() -> Command {
                 .short('t')
                 .num_args(1),
         )
+        .arg(
+            Arg::new("exactmw_min")
+                .required(false)
+                .long("exactmw_min")
+                .short('n')
+                .num_args(1),
+        )
+        .arg(
+            Arg::new("exactmw_max")
+                .required(false)
+                .long("exactmw_max")
+                .short('x')
+                .num_args(1),
+        )
 }
 
 pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
@@ -43,6 +57,8 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
     let smile = matches.get_one::<String>("smiles").unwrap();
     let result_limit = matches.get_one::<String>("result_limit");
     let tautomer_limit = matches.get_one::<String>("tautomer_limit");
+    let exactmw_min = matches.get_one::<String>("exactmw_min");
+    let exactmw_max = matches.get_one::<String>("exactmw_max");
 
     let result_limit = if let Some(result_limit) = result_limit {
         result_limit.parse::<usize>()?
@@ -54,6 +70,18 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         tautomer_limit.parse::<usize>()?
     } else {
         usize::try_from(10)?
+    };
+
+    let exactmw_min = if let Some(exactmw_min) = exactmw_min {
+        exactmw_min.parse::<usize>()?
+    } else {
+        usize::try_from(0)?
+    };
+
+    let exactmw_max = if let Some(exactmw_max) = exactmw_max {
+        exactmw_max.parse::<usize>()?
+    } else {
+        usize::try_from(10000)?
     };
 
     let index = open_index(index_path)?;
@@ -68,6 +96,8 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         fingerprint.0.as_bitslice(),
         &descriptors,
         result_limit,
+        exactmw_min,
+        exactmw_max,
     )?;
 
     let mut used_tautomers = false;
@@ -101,6 +131,8 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
                     taut_fingerprint.0.as_bitslice(),
                     &taut_descriptors,
                     result_limit,
+                    exactmw_min,
+                    exactmw_max,
                 );
 
                 let taut_results = match taut_results {

--- a/src/rest_api/api/search/basic_search.rs
+++ b/src/rest_api/api/search/basic_search.rs
@@ -1,0 +1,58 @@
+use crate::indexing::index_manager::IndexManager;
+use crate::rest_api::api::{GetQuerySearchResponse, QueryResponseError};
+use crate::search::aggregate_query_hits;
+use crate::search::basic_search::basic_search;
+use poem_openapi::payload::Json;
+
+pub fn v1_index_search_basic(
+    index_manager: &IndexManager,
+    index: String,
+    query: String,
+    limit: usize,
+) -> GetQuerySearchResponse {
+    let index = match index_manager.open(&index) {
+        Ok(index) => index,
+        Err(e) => {
+            return GetQuerySearchResponse::Err(Json(QueryResponseError {
+                error: e.to_string(),
+            }))
+        }
+    };
+
+    let reader = index.reader();
+    let reader = match reader {
+        Ok(reader) => reader,
+        Err(e) => {
+            return GetQuerySearchResponse::Err(Json(QueryResponseError {
+                error: e.to_string(),
+            }))
+        }
+    };
+
+    let searcher = reader.searcher();
+
+    let tantivy_limit = 10 * limit;
+    let results = basic_search(&searcher, &query, tantivy_limit);
+
+    let results = match results {
+        Ok(results) => results,
+        Err(e) => {
+            return GetQuerySearchResponse::Err(Json(QueryResponseError {
+                error: e.to_string(),
+            }))
+        }
+    };
+
+    let final_results = aggregate_query_hits(searcher, results, &query);
+
+    let final_results = match final_results {
+        Ok(final_results) => final_results,
+        Err(e) => {
+            return GetQuerySearchResponse::Err(Json(QueryResponseError {
+                error: e.to_string(),
+            }))
+        }
+    };
+
+    GetQuerySearchResponse::Ok(Json(final_results))
+}

--- a/src/rest_api/api/search/mod.rs
+++ b/src/rest_api/api/search/mod.rs
@@ -1,10 +1,27 @@
+mod basic_search;
 mod substructure_search;
 
+pub use basic_search::*;
 use poem_openapi::payload::Json;
 use poem_openapi_derive::{ApiResponse, Object};
 pub use substructure_search::*;
 
-use crate::search::StructureSearchHit;
+use crate::search::{QuerySearchHit, StructureSearchHit};
+
+#[derive(ApiResponse)]
+pub enum GetQuerySearchResponse {
+    #[oai(status = "200")]
+    Ok(Json<Vec<QuerySearchHit>>),
+    #[oai(status = "404")]
+    IndexDoesNotExist,
+    #[oai(status = "500")]
+    Err(Json<QueryResponseError>),
+}
+
+#[derive(Object, Debug)]
+pub struct QueryResponseError {
+    pub error: String,
+}
 
 #[derive(ApiResponse)]
 pub enum GetStructureSearchResponse {

--- a/src/rest_api/api/search/mod.rs
+++ b/src/rest_api/api/search/mod.rs
@@ -20,8 +20,3 @@ pub enum GetStructureSearchResponse {
 pub struct StructureResponseError {
     pub error: String,
 }
-
-#[derive(Object, Debug)]
-pub struct StructureSearchResponseError {
-    pub error: String,
-}

--- a/src/rest_api/api/search/substructure_search.rs
+++ b/src/rest_api/api/search/substructure_search.rs
@@ -17,8 +17,7 @@ pub fn v1_index_search_substructure(
     smile: String,
     result_limit: usize,
     tautomer_limit: usize,
-    exactmw_min: usize,
-    exactmw_max: usize,
+    extra_query: &String,
 ) -> GetStructureSearchResponse {
     let index = match index_manager.open(&index) {
         Ok(index) => index,
@@ -60,8 +59,7 @@ pub fn v1_index_search_substructure(
         fingerprint.0.as_bitslice(),
         &descriptors,
         result_limit,
-        exactmw_min,
-        exactmw_max,
+        extra_query,
     );
 
     let mut results = match results {
@@ -104,8 +102,7 @@ pub fn v1_index_search_substructure(
                     taut_fingerprint.0.as_bitslice(),
                     &taut_descriptors,
                     result_limit,
-                    exactmw_min,
-                    exactmw_max,
+                    extra_query,
                 );
 
                 let taut_results = match taut_results {

--- a/src/rest_api/api/search/substructure_search.rs
+++ b/src/rest_api/api/search/substructure_search.rs
@@ -17,6 +17,8 @@ pub fn v1_index_search_substructure(
     smile: String,
     result_limit: usize,
     tautomer_limit: usize,
+    exactmw_min: usize,
+    exactmw_max: usize,
 ) -> GetStructureSearchResponse {
     let index = match index_manager.open(&index) {
         Ok(index) => index,
@@ -58,6 +60,8 @@ pub fn v1_index_search_substructure(
         fingerprint.0.as_bitslice(),
         &descriptors,
         result_limit,
+        exactmw_min,
+        exactmw_max,
     );
 
     let mut results = match results {
@@ -100,6 +104,8 @@ pub fn v1_index_search_substructure(
                     taut_fingerprint.0.as_bitslice(),
                     &taut_descriptors,
                     result_limit,
+                    exactmw_min,
+                    exactmw_max,
                 );
 
                 let taut_results = match taut_results {

--- a/src/rest_api/openapi_server.rs
+++ b/src/rest_api/openapi_server.rs
@@ -162,8 +162,7 @@ impl Api {
         smile: Query<String>,
         result_limit: Query<Option<usize>>,
         tautomer_limit: Query<Option<usize>>,
-        exactmw_min: Query<Option<usize>>,
-        exactmw_max: Query<Option<usize>>,
+        extra_query: Query<Option<String>>,
     ) -> GetStructureSearchResponse {
         let result_limit = if let Some(result_limit) = result_limit.0 {
             result_limit
@@ -177,16 +176,10 @@ impl Api {
             usize::try_from(10).unwrap()
         };
 
-        let exactmw_min = if let Some(exactmw_min) = exactmw_min.0 {
-            exactmw_min
+        let extra_query = if let Some(extra_query) = extra_query.0 {
+            extra_query
         } else {
-            usize::try_from(0).unwrap()
-        };
-
-        let exactmw_max = if let Some(exactmw_max) = exactmw_max.0 {
-            exactmw_max
-        } else {
-            usize::try_from(10000).unwrap()
+            "".to_string()
         };
 
         v1_index_search_substructure(
@@ -195,8 +188,7 @@ impl Api {
             smile.0,
             result_limit,
             tautomer_limit,
-            exactmw_min,
-            exactmw_max,
+            &extra_query,
         )
     }
 }

--- a/src/rest_api/openapi_server.rs
+++ b/src/rest_api/openapi_server.rs
@@ -12,10 +12,11 @@ use crate::{
     indexing::index_manager::IndexManager,
     rest_api::{
         api::{
-            v1_get_index, v1_index_search_substructure, v1_list_indexes, v1_list_schemas,
-            v1_post_index, v1_post_index_bulk, v1_standardize, BulkRequest, GetIndexesResponse,
-            GetStructureSearchResponse, ListIndexesResponse, ListSchemasResponse,
-            PostIndexResponse, PostIndexesBulkIndexResponse, StandardizeResponse,
+            v1_get_index, v1_index_search_basic, v1_index_search_substructure, v1_list_indexes,
+            v1_list_schemas, v1_post_index, v1_post_index_bulk, v1_standardize, BulkRequest,
+            GetIndexesResponse, GetQuerySearchResponse, GetStructureSearchResponse,
+            ListIndexesResponse, ListSchemasResponse, PostIndexResponse,
+            PostIndexesBulkIndexResponse, StandardizeResponse,
         },
         models::Smile,
     },
@@ -134,6 +135,23 @@ impl Api {
         bulk_request: Json<BulkRequest>,
     ) -> PostIndexesBulkIndexResponse {
         v1_post_index_bulk(&self.index_manager, index.to_string(), bulk_request.0).await
+    }
+
+    #[oai(path = "/v1/indexes/:index/search/basic", method = "get")]
+    /// Perform basic query search against index
+    pub async fn v1_index_search_basic(
+        &self,
+        index: Path<String>,
+        query: Query<String>,
+        limit: Query<Option<usize>>,
+    ) -> GetQuerySearchResponse {
+        let limit = if let Some(limit) = limit.0 {
+            limit
+        } else {
+            usize::try_from(1000).unwrap()
+        };
+
+        v1_index_search_basic(&self.index_manager, index.to_string(), query.0, limit)
     }
 
     #[oai(path = "/v1/indexes/:index/search/substructure", method = "get")]

--- a/src/rest_api/openapi_server.rs
+++ b/src/rest_api/openapi_server.rs
@@ -162,6 +162,8 @@ impl Api {
         smile: Query<String>,
         result_limit: Query<Option<usize>>,
         tautomer_limit: Query<Option<usize>>,
+        exactmw_min: Query<Option<usize>>,
+        exactmw_max: Query<Option<usize>>,
     ) -> GetStructureSearchResponse {
         let result_limit = if let Some(result_limit) = result_limit.0 {
             result_limit
@@ -175,12 +177,26 @@ impl Api {
             usize::try_from(10).unwrap()
         };
 
+        let exactmw_min = if let Some(exactmw_min) = exactmw_min.0 {
+            exactmw_min
+        } else {
+            usize::try_from(0).unwrap()
+        };
+
+        let exactmw_max = if let Some(exactmw_max) = exactmw_max.0 {
+            exactmw_max
+        } else {
+            usize::try_from(10000).unwrap()
+        };
+
         v1_index_search_substructure(
             &self.index_manager,
             index.to_string(),
             smile.0,
             result_limit,
             tautomer_limit,
+            exactmw_min,
+            exactmw_max,
         )
     }
 }

--- a/src/search/basic_search.rs
+++ b/src/search/basic_search.rs
@@ -1,14 +1,18 @@
-use tantivy::{collector::TopDocs, query::QueryParser, DocAddress, Score, Searcher};
+use tantivy::{collector::TopDocs, query::QueryParser, DocAddress, Searcher};
 
 #[allow(clippy::ptr_arg)]
 pub fn basic_search(
     searcher: &Searcher,
     query: &String,
     limit: usize,
-) -> eyre::Result<Vec<(Score, DocAddress)>> {
+) -> eyre::Result<Vec<DocAddress>> {
     let index = searcher.index();
     let query_parser = QueryParser::for_index(index, vec![]);
     let query = query_parser.parse_query(query)?;
     let results = searcher.search(&query, &TopDocs::with_limit(limit))?;
-    Ok(results)
+    let final_results = results
+        .into_iter()
+        .map(|result| result.1)
+        .collect::<Vec<DocAddress>>();
+    Ok(final_results)
 }

--- a/src/search/basic_search.rs
+++ b/src/search/basic_search.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use tantivy::{collector::TopDocs, query::QueryParser, DocAddress, Searcher};
 
 #[allow(clippy::ptr_arg)]
@@ -5,7 +6,7 @@ pub fn basic_search(
     searcher: &Searcher,
     query: &String,
     limit: usize,
-) -> eyre::Result<Vec<DocAddress>> {
+) -> eyre::Result<HashSet<DocAddress>> {
     let index = searcher.index();
     let query_parser = QueryParser::for_index(index, vec![]);
     let query = query_parser.parse_query(query)?;
@@ -13,6 +14,6 @@ pub fn basic_search(
     let final_results = results
         .into_iter()
         .map(|result| result.1)
-        .collect::<Vec<DocAddress>>();
+        .collect::<HashSet<DocAddress>>();
     Ok(final_results)
 }

--- a/src/search/substructure_search.rs
+++ b/src/search/substructure_search.rs
@@ -48,7 +48,7 @@ pub fn substructure_search(
 
     let mut filtered_results2: HashSet<DocAddress> = HashSet::new();
 
-    for (_score, docaddr) in filtered_results1 {
+    for docaddr in filtered_results1 {
         if filtered_results2.len() >= result_limit {
             break;
         }


### PR DESCRIPTION
Fleshes out the basic search (i.e. query) API endpoint. Also makes CLI methods correspond more closely to API endpoints for substructure and basic search.

Also the substructure search endpoint can now take an optional extra_query argument. This allows the user to add specifications for what kind of structures are to be returned. (e.g. molecular weight constraints)