### PR TITLE
Fix benchmark and compilation errors

### DIFF
--- a/benches/fingerprint_benches.rs
+++ b/benches/fingerprint_benches.rs
@@ -9,10 +9,10 @@ use test::Bencher;
 #[bench]
 fn bench_tanimoto_distance(b: &mut Bencher) {
     let smiles1 = "[N]Cc1cncc2c(=O)c3cccc(CCC(=O)O)c3[nH]c12";
-    let (_proc_smiles1, fingerprint1, _descriptors1) = process_cpd(smiles1).unwrap();
+    let (_proc_smiles1, fingerprint1, _descriptors1) = process_cpd(smiles1, false).unwrap();
 
     let smiles2 = "CCc1cccc2c(=O)c3cncc(CN)c3[nH]c12";
-    let (_proc_smiles2, fingerprint2, _descriptors2) = process_cpd(smiles2).unwrap();
+    let (_proc_smiles2, fingerprint2, _descriptors2) = process_cpd(smiles2, false).unwrap();
 
     b.iter(|| fingerprint1.tanimoto_distance(&fingerprint2));
 }

--- a/src/rest_api/api/compound_processing/convert_mol_block_to_smiles.rs
+++ b/src/rest_api/api/compound_processing/convert_mol_block_to_smiles.rs
@@ -50,13 +50,11 @@ pub async fn v1_convert_mol_block_to_smiles(
 
 #[cfg(test)]
 mod tests {
-    use super::ConvertedSmilesResponse;
     use super::*;
     use crate::indexing::index_manager::IndexManager;
     use crate::rest_api::openapi_server::Api;
     use poem::{handler, Route};
     use poem_openapi::param::Query;
-    use poem_openapi::payload::Json;
 
     const MOL_BLOCK: &'static str = r#"
   -OEChem-05172223082D


### PR DESCRIPTION
Fixes an out-of-date invocation of the `process_cpd` method in the benchmarks. Also remove some redundant imports.