### PR TITLE
Enable doc and index deletion

### DIFF
--- a/src/command_line/indexing/bulk_delete.rs
+++ b/src/command_line/indexing/bulk_delete.rs
@@ -60,9 +60,9 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
     let query_parser = QueryParser::for_index(&index, vec![]);
 
     let scaffolds = if use_scaffolds {
-        &PARSED_SCAFFOLDS
+        Some(&PARSED_SCAFFOLDS)
     } else {
-        &Vec::new()
+        None
     };
 
     for smiles in smiles_list {
@@ -71,10 +71,9 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         if let Ok((canon_taut, fingerprint, descriptors)) = attributes {
             let canon_smiles = canon_taut.as_smiles();
 
-            let matching_scaffolds = if !scaffolds.is_empty() {
-                scaffold_search(&canon_taut, scaffolds)?
-            } else {
-                Vec::new()
+            let matching_scaffolds = match scaffolds {
+                Some(scaffolds) => Some(scaffold_search(&canon_taut, scaffolds)?),
+                None => None,
             };
 
             let result = identity_search(

--- a/src/command_line/indexing/bulk_delete.rs
+++ b/src/command_line/indexing/bulk_delete.rs
@@ -24,9 +24,9 @@ pub fn command() -> Command {
                 .num_args(1),
         )
         .arg(
-            Arg::new("use_scaffolds")
+            Arg::new("use-scaffolds")
                 .required(false)
-                .long("use_scaffolds")
+                .long("use-scaffolds")
                 .short('u')
                 .num_args(1),
         )
@@ -41,7 +41,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         .ok_or(eyre::eyre!("Failed to extract smiles list"))?
         .split(',')
         .collect::<Vec<_>>();
-    let use_scaffolds = matches.get_one::<String>("use_scaffolds");
+    let use_scaffolds = matches.get_one::<String>("use-scaffolds");
 
     // by default, we will use scaffold-based indexing
     let use_scaffolds = if let Some(use_scaffolds) = use_scaffolds {

--- a/src/command_line/indexing/bulk_delete.rs
+++ b/src/command_line/indexing/bulk_delete.rs
@@ -72,7 +72,7 @@ fn create_delete_query(smiles: &str, query_parser: &QueryParser) -> eyre::Result
     };
 
     let raw_query =
-        crate::search::identity_search::build_query(&descriptors, "", &matching_scaffolds);
+        crate::search::identity_search::build_identity_query(&descriptors, "", &matching_scaffolds);
     let query = format!("{raw_query} AND smiles:\"{canon_smiles}\"");
     let parsed_query = query_parser.parse_query(&query)?;
     Ok(parsed_query)

--- a/src/command_line/indexing/bulk_delete.rs
+++ b/src/command_line/indexing/bulk_delete.rs
@@ -1,0 +1,121 @@
+use crate::command_line::{indexing::split_path, prelude::*};
+use crate::indexing::index_manager::IndexManager;
+use crate::search::identity_search::identity_search;
+use crate::search::prepare_query_structure;
+use crate::search::scaffold_search::{scaffold_search, PARSED_SCAFFOLDS};
+use std::ops::Deref;
+use tantivy::query::QueryParser;
+
+pub const NAME: &str = "bulk-delete";
+
+pub fn command() -> Command {
+    Command::new(NAME)
+        .arg(
+            Arg::new("index-path")
+                .required(true)
+                .long("index-path")
+                .short('i')
+                .num_args(1),
+        )
+        .arg(
+            Arg::new("smiles-list")
+                .required(false)
+                .long("smiles-list")
+                .short('s')
+                .num_args(1),
+        )
+        .arg(
+            Arg::new("use_scaffolds")
+                .required(false)
+                .long("use_scaffolds")
+                .short('u')
+                .num_args(1),
+        )
+}
+
+pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
+    let index_path = matches
+        .get_one::<String>("index-path")
+        .ok_or(eyre::eyre!("Failed to extract index path"))?;
+    let smiles_list = matches
+        .get_one::<String>("smiles-list")
+        .ok_or(eyre::eyre!("Failed to extract smiles list"))?
+        .split(',')
+        .collect::<Vec<_>>();
+    let use_scaffolds = matches.get_one::<String>("use_scaffolds");
+
+    // by default, we will use scaffold-based indexing
+    let use_scaffolds = if let Some(use_scaffolds) = use_scaffolds {
+        matches!(use_scaffolds.as_str(), "true")
+    } else {
+        true
+    };
+
+    let (storage_dir, index_name) = split_path(index_path)?;
+    let index_manager = IndexManager::new(storage_dir.deref(), false)?;
+    let index = index_manager.open(index_name.deref())?;
+    let mut deleter = index.writer(16 * 1024 * 1024)?;
+    let reader = index.reader()?;
+    let searcher = reader.searcher();
+    let query_parser = QueryParser::for_index(&index, vec![]);
+
+    let scaffolds = if use_scaffolds {
+        &PARSED_SCAFFOLDS
+    } else {
+        &Vec::new()
+    };
+
+    for smiles in smiles_list {
+        let attributes = prepare_query_structure(smiles);
+
+        if let Ok((canon_taut, fingerprint, descriptors)) = attributes {
+            let canon_smiles = canon_taut.as_smiles();
+
+            let matching_scaffolds = if !scaffolds.is_empty() {
+                scaffold_search(&canon_taut, scaffolds)?
+            } else {
+                Vec::new()
+            };
+
+            let result = identity_search(
+                &searcher,
+                &canon_taut,
+                &matching_scaffolds,
+                fingerprint.0.as_bitslice(),
+                &descriptors,
+                "",
+            );
+
+            if let Ok(Some(_)) = result {
+                let raw_query = crate::search::identity_search::build_query(
+                    &descriptors,
+                    "",
+                    &matching_scaffolds,
+                );
+                let query = format!("{raw_query} AND smiles:\"{canon_smiles}\"");
+
+                let query = query_parser.parse_query(&query);
+
+                if query.is_ok() {
+                    let query_result = deleter.delete_query(query.unwrap());
+                    if query_result.is_ok() {
+                        let opstamp = deleter.commit();
+                        if opstamp.is_ok() {
+                            println!("Deleting \"{}\"", canon_smiles);
+                        }
+                    }
+                }
+            } else {
+                println!("Entry {:?} was not found in the database", canon_smiles);
+            }
+        } else {
+            println!(
+                "Invalid smiles detected for {:?}: {:?}",
+                smiles,
+                attributes.err().unwrap()
+            )
+        }
+    }
+
+    Ok(())
+}

--- a/src/command_line/indexing/bulk_delete.rs
+++ b/src/command_line/indexing/bulk_delete.rs
@@ -77,3 +77,62 @@ fn create_delete_query(smiles: &str, query_parser: &QueryParser) -> eyre::Result
     let parsed_query = query_parser.parse_query(&query)?;
     Ok(parsed_query)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::command_line::indexing::bulk_delete::create_delete_query;
+    use crate::search::compound_processing::process_cpd;
+    use serde_json::json;
+    use tantivy::query::QueryParser;
+    use tantivy::schema::{JsonObjectOptions, SchemaBuilder, FAST, INDEXED, STORED, STRING, TEXT};
+    use tantivy::{doc, IndexBuilder};
+
+    #[test]
+    fn test_create_delete_query() {
+        let test_smiles = "C1=CC=CC=C1C(C)C";
+        let (canon_taut, fingerprint, descriptors) = process_cpd(test_smiles, false).unwrap();
+
+        let mut builder = SchemaBuilder::new();
+
+        let smiles_field = builder.add_text_field("smiles", STRING | STORED);
+        let fingerprint_field = builder.add_bytes_field("fingerprint", FAST | STORED);
+
+        let mut doc = doc!(
+            smiles_field => canon_taut.as_smiles(),
+            fingerprint_field => fingerprint.0.clone().into_vec()
+        );
+
+        for (descriptor, val) in &descriptors {
+            if descriptor.starts_with("Num") || descriptor.starts_with("lipinski") {
+                let current_field = builder.add_i64_field(descriptor, INDEXED | STORED);
+
+                doc.add_field_value(current_field, *val as i64);
+            } else {
+                let current_field = builder.add_f64_field(descriptor, FAST | STORED);
+
+                doc.add_field_value(current_field, *val);
+            }
+        }
+
+        let json_options: JsonObjectOptions =
+            JsonObjectOptions::from(TEXT | STORED).set_expand_dots_enabled();
+
+        let extra_data_field = builder.add_json_field("extra_data", json_options);
+
+        doc.add_field_value(extra_data_field, json!({"extra_data": ""}));
+
+        let schema = builder.build();
+        let builder = IndexBuilder::new().schema(schema);
+        let index = builder.create_in_ram().unwrap();
+
+        let mut index_writer = index.writer_with_num_threads(1, 50 * 1024 * 1024).unwrap();
+
+        index_writer.add_document(doc).unwrap();
+        index_writer.commit().unwrap();
+
+        let query_parser = QueryParser::for_index(&index, vec![]);
+
+        let parsed_query = create_delete_query(test_smiles, &query_parser);
+        assert!(parsed_query.is_ok());
+    }
+}

--- a/src/command_line/indexing/bulk_index.rs
+++ b/src/command_line/indexing/bulk_index.rs
@@ -124,11 +124,11 @@ fn create_tantivy_doc(
     );
 
     let scaffold_matches = scaffold_search(&canon_taut, &PARSED_SCAFFOLDS)?;
-    let mut scaffold_json = Value::Null;
-    if !scaffold_matches.is_empty() {
-        scaffold_json =
-            serde_json::from_str(format!(r#"{{ "scaffolds": {:?} }}"#, scaffold_matches).as_str())?;
-    }
+
+    let scaffold_json = match scaffold_matches.is_empty() {
+        true => Value::Null,
+        false => serde_json::json!({"scaffolds": scaffold_matches}),
+    };
 
     let extra_data_json = combine_json_objects(Some(scaffold_json), extra_data);
     if let Some(extra_data_json) = extra_data_json {

--- a/src/command_line/indexing/bulk_index.rs
+++ b/src/command_line/indexing/bulk_index.rs
@@ -21,7 +21,7 @@ pub fn command() -> Command {
         )
         .arg(
             Arg::new("json-path")
-                .required(false)
+                .required(true)
                 .long("json-path")
                 .short('j')
                 .num_args(1),

--- a/src/command_line/indexing/mod.rs
+++ b/src/command_line/indexing/mod.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+pub mod bulk_delete;
 pub mod bulk_index;
 pub mod create_index;
 pub mod delete_index;

--- a/src/command_line/search/identity_search.rs
+++ b/src/command_line/search/identity_search.rs
@@ -69,15 +69,14 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
     let (query_canon_taut, fingerprint, descriptors) = prepare_query_structure(query_smiles)?;
 
     let scaffolds = if use_scaffolds {
-        &PARSED_SCAFFOLDS
+        Some(&PARSED_SCAFFOLDS)
     } else {
-        &Vec::new()
+        None
     };
 
-    let matching_scaffolds = if !scaffolds.is_empty() {
-        scaffold_search(&query_canon_taut, scaffolds)?
-    } else {
-        Vec::new()
+    let matching_scaffolds = match scaffolds {
+        Some(scaffolds) => Some(scaffold_search(&query_canon_taut, scaffolds)?),
+        None => None,
     };
 
     let result = identity_search(

--- a/src/command_line/search/identity_search.rs
+++ b/src/command_line/search/identity_search.rs
@@ -28,6 +28,7 @@ pub fn command() -> Command {
                 .required(false)
                 .long("extra-query")
                 .short('e')
+                .help("In case of duplicate smiles entries, it may be helpful to add an extra differentiating query (e.g. using data from the 'extra_data' field)")
                 .num_args(1),
         )
         .arg(
@@ -35,6 +36,7 @@ pub fn command() -> Command {
                 .required(false)
                 .long("use-scaffolds")
                 .short('u')
+                .help("By default scaffolds are computed for the smiles input to enable accelerated searching")
                 .num_args(1),
         )
 }

--- a/src/command_line/search/identity_search.rs
+++ b/src/command_line/search/identity_search.rs
@@ -24,16 +24,16 @@ pub fn command() -> Command {
                 .num_args(1),
         )
         .arg(
-            Arg::new("extra_query")
+            Arg::new("extra-query")
                 .required(false)
-                .long("extra_query")
+                .long("extra-query")
                 .short('e')
                 .num_args(1),
         )
         .arg(
-            Arg::new("use_scaffolds")
+            Arg::new("use-scaffolds")
                 .required(false)
-                .long("use_scaffolds")
+                .long("use-scaffolds")
                 .short('u')
                 .num_args(1),
         )
@@ -46,8 +46,8 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
     let query_smiles = matches
         .get_one::<String>("smiles")
         .ok_or(eyre::eyre!("Failed to extract SMILES"))?;
-    let extra_query = matches.get_one::<String>("extra_query");
-    let use_scaffolds = matches.get_one::<String>("use_scaffolds");
+    let extra_query = matches.get_one::<String>("extra-query");
+    let use_scaffolds = matches.get_one::<String>("use-scaffolds");
 
     let extra_query = if let Some(extra_query) = extra_query {
         extra_query.clone()

--- a/src/command_line/search/substructure_search.rs
+++ b/src/command_line/search/substructure_search.rs
@@ -42,6 +42,7 @@ pub fn command() -> Command {
                 .required(false)
                 .long("extra-query")
                 .short('e')
+                .help("An extra query (e.g. \"exactmw:[50 TO 100]\") may be helpful in case you want to further restrict the kinds of substructure matches that are returned")
                 .num_args(1),
         )
         .arg(
@@ -49,6 +50,7 @@ pub fn command() -> Command {
                 .required(false)
                 .long("use-scaffolds")
                 .short('u')
+                .help("By default scaffolds are computed for the smiles input to enable accelerated searching")
                 .num_args(1),
         )
 }

--- a/src/command_line/search/substructure_search.rs
+++ b/src/command_line/search/substructure_search.rs
@@ -97,15 +97,14 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
     let (query_canon_taut, fingerprint, descriptors) = prepare_query_structure(smiles)?;
 
     let scaffolds = if use_scaffolds {
-        &PARSED_SCAFFOLDS
+        Some(&PARSED_SCAFFOLDS)
     } else {
-        &Vec::new()
+        None
     };
 
-    let matching_scaffolds = if !scaffolds.is_empty() {
-        scaffold_search(&query_canon_taut, scaffolds)?
-    } else {
-        Vec::new()
+    let matching_scaffolds = match scaffolds {
+        Some(scaffolds) => Some(scaffold_search(&query_canon_taut, scaffolds)?),
+        None => None,
     };
 
     let mut results = substructure_search(
@@ -143,10 +142,9 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
 
                 let (taut_fingerprint, taut_descriptors) = taut_attributes;
 
-                let matching_scaffolds = if !scaffolds.is_empty() {
-                    scaffold_search(&test_taut, scaffolds)?
-                } else {
-                    Vec::new()
+                let matching_scaffolds = match scaffolds {
+                    Some(scaffolds) => Some(scaffold_search(&test_taut, scaffolds)?),
+                    None => None,
                 };
 
                 let taut_results = substructure_search(

--- a/src/command_line/search/substructure_search.rs
+++ b/src/command_line/search/substructure_search.rs
@@ -24,30 +24,30 @@ pub fn command() -> Command {
                 .num_args(1),
         )
         .arg(
-            Arg::new("result_limit")
+            Arg::new("result-limit")
                 .required(false)
-                .long("result_limit")
+                .long("result-limit")
                 .short('r')
                 .num_args(1),
         )
         .arg(
-            Arg::new("tautomer_limit")
+            Arg::new("tautomer-limit")
                 .required(false)
-                .long("tautomer_limit")
+                .long("tautomer-limit")
                 .short('t')
                 .num_args(1),
         )
         .arg(
-            Arg::new("extra_query")
+            Arg::new("extra-query")
                 .required(false)
-                .long("extra_query")
+                .long("extra-query")
                 .short('e')
                 .num_args(1),
         )
         .arg(
-            Arg::new("use_scaffolds")
+            Arg::new("use-scaffolds")
                 .required(false)
-                .long("use_scaffolds")
+                .long("use-scaffolds")
                 .short('u')
                 .num_args(1),
         )
@@ -60,10 +60,10 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
     let smiles = matches
         .get_one::<String>("smiles")
         .ok_or(eyre::eyre!("Failed to extract SMILES"))?;
-    let result_limit = matches.get_one::<String>("result_limit");
-    let tautomer_limit = matches.get_one::<String>("tautomer_limit");
-    let extra_query = matches.get_one::<String>("extra_query");
-    let use_scaffolds = matches.get_one::<String>("use_scaffolds");
+    let result_limit = matches.get_one::<String>("result-limit");
+    let tautomer_limit = matches.get_one::<String>("tautomer-limit");
+    let extra_query = matches.get_one::<String>("extra-query");
+    let use_scaffolds = matches.get_one::<String>("use-scaffolds");
 
     let result_limit = if let Some(result_limit) = result_limit {
         result_limit.parse::<usize>()?

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ async fn main() -> eyre::Result<()> {
     let app = Command::new("cheminee")
         .subcommand_required(true)
         .subcommand(command_line::indexing::bulk_index::command())
+        .subcommand(command_line::indexing::bulk_delete::command())
         .subcommand(command_line::indexing::create_index::command())
         .subcommand(command_line::indexing::delete_index::command())
         .subcommand(command_line::indexing::index_sdf::command())
@@ -34,6 +35,9 @@ async fn main() -> eyre::Result<()> {
     let matches = match matches.subcommand().unwrap() {
         (command_line::indexing::bulk_index::NAME, matches) => {
             command_line::indexing::bulk_index::action(matches)
+        }
+        (command_line::indexing::bulk_delete::NAME, matches) => {
+            command_line::indexing::bulk_delete::action(matches)
         }
         (command_line::indexing::create_index::NAME, matches) => {
             command_line::indexing::create_index::action(matches)

--- a/src/rest_api/api/indexing/bulk_delete.rs
+++ b/src/rest_api/api/indexing/bulk_delete.rs
@@ -88,7 +88,7 @@ fn bulk_request_doc_to_query(
     };
 
     let raw_query =
-        crate::search::identity_search::build_query(&descriptors, "", &matching_scaffolds);
+        crate::search::identity_search::build_identity_query(&descriptors, "", &matching_scaffolds);
     let query = format!("{raw_query} AND smiles:\"{canon_smiles}\"");
     let parsed_query = query_parser.parse_query(&query)?;
     Ok(parsed_query)

--- a/src/rest_api/api/indexing/bulk_delete.rs
+++ b/src/rest_api/api/indexing/bulk_delete.rs
@@ -1,0 +1,95 @@
+use crate::indexing::index_manager::IndexManager;
+use crate::rest_api::api::{
+    BulkRequest, BulkRequestDoc, PostIndexBulkResponseError, PostIndexBulkResponseOk,
+    PostIndexBulkResponseOkStatus, PostIndexesBulkDeleteResponse,
+};
+use crate::search::compound_processing::process_cpd;
+use crate::search::scaffold_search::{scaffold_search, PARSED_SCAFFOLDS};
+use poem_openapi::payload::Json;
+use tantivy::query::{Query, QueryParser};
+
+pub async fn v1_post_bulk_delete(
+    index_manager: &IndexManager,
+    index: String,
+    bulk_request: BulkRequest,
+) -> PostIndexesBulkDeleteResponse {
+    let index = match index_manager.open(&index) {
+        Ok(index) => index,
+        Err(e) => {
+            return PostIndexesBulkDeleteResponse::Err(Json(PostIndexBulkResponseError {
+                error: e.to_string(),
+            }))
+        }
+    };
+
+    let mut deleter = match index.writer(16 * 1024 * 1024) {
+        Ok(deleter) => deleter,
+        Err(e) => {
+            return PostIndexesBulkDeleteResponse::Err(Json(PostIndexBulkResponseError {
+                error: e.to_string(),
+            }))
+        }
+    };
+
+    let query_parser = QueryParser::for_index(&index, vec![]);
+
+    let mut document_delete_statuses = Vec::with_capacity(bulk_request.docs.len());
+    for bulk_request_doc in bulk_request.docs {
+        let parsed_query = bulk_request_doc_to_query(&bulk_request_doc, &query_parser);
+
+        let status = match parsed_query {
+            Ok(parsed_query) => {
+                let delete_operation = deleter.delete_query(parsed_query);
+
+                match delete_operation {
+                    Ok(opstamp) => PostIndexBulkResponseOkStatus {
+                        opcode: Some(opstamp),
+                        error: None,
+                    },
+                    Err(e) => PostIndexBulkResponseOkStatus {
+                        opcode: None,
+                        error: Some(e.to_string()),
+                    },
+                }
+            }
+            Err(e) => PostIndexBulkResponseOkStatus {
+                opcode: None,
+                error: Some(e.to_string()),
+            },
+        };
+        document_delete_statuses.push(status);
+    }
+
+    match deleter.commit() {
+        Ok(_) => (),
+        Err(e) => {
+            return PostIndexesBulkDeleteResponse::Err(Json(PostIndexBulkResponseError {
+                error: e.to_string(),
+            }))
+        }
+    }
+
+    PostIndexesBulkDeleteResponse::Ok(Json(PostIndexBulkResponseOk {
+        statuses: document_delete_statuses,
+    }))
+}
+
+fn bulk_request_doc_to_query(
+    bulk_request_doc: &BulkRequestDoc,
+    query_parser: &QueryParser,
+) -> eyre::Result<Box<dyn Query>> {
+    let (canon_taut, _fingerprint, descriptors) = process_cpd(&bulk_request_doc.smiles, false)?;
+
+    let canon_smiles = canon_taut.as_smiles();
+    let matching_scaffolds = scaffold_search(&canon_taut, &PARSED_SCAFFOLDS);
+    let matching_scaffolds = match matching_scaffolds {
+        Ok(matching_scaffolds) => Some(matching_scaffolds),
+        Err(_) => None,
+    };
+
+    let raw_query =
+        crate::search::identity_search::build_query(&descriptors, "", &matching_scaffolds);
+    let query = format!("{raw_query} AND smiles:\"{canon_smiles}\"");
+    let parsed_query = query_parser.parse_query(&query)?;
+    Ok(parsed_query)
+}

--- a/src/rest_api/api/indexing/bulk_index.rs
+++ b/src/rest_api/api/indexing/bulk_index.rs
@@ -140,11 +140,10 @@ fn bulk_request_doc_to_tantivy_doc(
     let scaffolds = &PARSED_SCAFFOLDS;
     let scaffold_matches = scaffold_search(&tautomer, scaffolds)?;
 
-    let mut scaffold_json = Value::Null;
-    if !scaffold_matches.is_empty() {
-        scaffold_json =
-            serde_json::from_str(format!(r#"{{ "scaffolds": {:?} }}"#, scaffold_matches).as_str())?;
-    }
+    let scaffold_json = match scaffold_matches.is_empty() {
+        true => Value::Null,
+        false => serde_json::json!({"scaffolds": scaffold_matches}),
+    };
 
     let extra_data_json = combine_json_objects(Some(scaffold_json), bulk_request_doc.extra_data);
     if let Some(extra_data_json) = extra_data_json {

--- a/src/rest_api/api/indexing/delete_index.rs
+++ b/src/rest_api/api/indexing/delete_index.rs
@@ -1,0 +1,35 @@
+use crate::indexing::index_manager::IndexManager;
+use crate::rest_api::api::{DeleteIndexError, DeleteIndexResponse, IndexMeta};
+use crate::schema::LIBRARY;
+use poem_openapi::payload::Json;
+
+pub fn v1_delete_index(index_manager: &IndexManager, index_name: String) -> DeleteIndexResponse {
+    let index = match index_manager.open(&index_name) {
+        Ok(index) => index,
+        Err(e) => {
+            return DeleteIndexResponse::Err(Json(DeleteIndexError {
+                error: e.to_string(),
+            }))
+        }
+    };
+
+    let schema = index.schema();
+    let mut schema_name = "";
+    for (k, v) in LIBRARY.clone().into_iter() {
+        if schema == v {
+            schema_name = k
+        }
+    }
+
+    let delete_operation = index_manager.delete(&index_name);
+
+    match delete_operation {
+        Ok(_) => DeleteIndexResponse::Ok(Json(IndexMeta {
+            name: index_name,
+            schema: schema_name.to_string(),
+        })),
+        Err(e) => DeleteIndexResponse::Err(Json(DeleteIndexError {
+            error: e.to_string(),
+        })),
+    }
+}

--- a/src/rest_api/api/indexing/index_management.rs
+++ b/src/rest_api/api/indexing/index_management.rs
@@ -46,6 +46,16 @@ pub enum PostIndexesBulkIndexResponse {
 }
 
 #[derive(ApiResponse)]
+pub enum PostIndexesBulkDeleteResponse {
+    #[oai(status = "200")]
+    Ok(Json<PostIndexBulkResponseOk>),
+    #[oai(status = "404")]
+    IndexDoesNotExist,
+    #[oai(status = "500")]
+    Err(Json<PostIndexBulkResponseError>),
+}
+
+#[derive(ApiResponse)]
 pub enum PostIndexResponse {
     #[oai(status = "200")]
     Ok(Json<IndexMeta>),
@@ -102,8 +112,6 @@ pub struct PostIndexBulkResponseError {
 #[derive(Object, Debug)]
 pub struct PostIndexBulkResponseOk {
     pub statuses: Vec<PostIndexBulkResponseOkStatus>,
-    // pub errors: usize,
-    // pub seconds_taken: usize,
 }
 
 #[derive(Object, Debug)]

--- a/src/rest_api/api/indexing/index_management.rs
+++ b/src/rest_api/api/indexing/index_management.rs
@@ -65,6 +65,16 @@ pub enum PostIndexResponse {
     Err(Json<CreateIndexError>),
 }
 
+#[derive(ApiResponse)]
+pub enum DeleteIndexResponse {
+    #[oai(status = "200")]
+    Ok(Json<IndexMeta>),
+    #[oai(status = "404")]
+    IndexDoesNotExist,
+    #[oai(status = "500")]
+    Err(Json<DeleteIndexError>),
+}
+
 #[derive(Object, Debug)]
 pub struct BulkRequest {
     pub docs: Vec<BulkRequestDoc>,
@@ -79,6 +89,11 @@ pub struct BulkRequestDoc {
 
 #[derive(Object, Debug)]
 pub struct CreateIndexError {
+    pub error: String,
+}
+
+#[derive(Object, Debug)]
+pub struct DeleteIndexError {
     pub error: String,
 }
 

--- a/src/rest_api/api/indexing/index_management.rs
+++ b/src/rest_api/api/indexing/index_management.rs
@@ -46,13 +46,13 @@ pub enum PostIndexesBulkIndexResponse {
 }
 
 #[derive(ApiResponse)]
-pub enum PostIndexesBulkDeleteResponse {
+pub enum DeleteIndexesBulkDeleteResponse {
     #[oai(status = "200")]
-    Ok(Json<PostIndexBulkResponseOk>),
+    Ok(Json<DeleteIndexBulkResponseOk>),
     #[oai(status = "404")]
     IndexDoesNotExist,
     #[oai(status = "500")]
-    Err(Json<PostIndexBulkResponseError>),
+    Err(Json<DeleteIndexBulkResponseError>),
 }
 
 #[derive(ApiResponse)]
@@ -116,6 +116,22 @@ pub struct PostIndexBulkResponseOk {
 
 #[derive(Object, Debug)]
 pub struct PostIndexBulkResponseOkStatus {
+    pub opcode: Option<Opstamp>,
+    pub error: Option<String>,
+}
+
+#[derive(Object, Debug)]
+pub struct DeleteIndexBulkResponseError {
+    pub error: String,
+}
+
+#[derive(Object, Debug)]
+pub struct DeleteIndexBulkResponseOk {
+    pub statuses: Vec<DeleteIndexBulkResponseOkStatus>,
+}
+
+#[derive(Object, Debug)]
+pub struct DeleteIndexBulkResponseOkStatus {
     pub opcode: Option<Opstamp>,
     pub error: Option<String>,
 }

--- a/src/rest_api/api/indexing/mod.rs
+++ b/src/rest_api/api/indexing/mod.rs
@@ -7,6 +7,9 @@ pub use bulk_delete::*;
 mod create_index;
 pub use create_index::*;
 
+mod delete_index;
+pub use delete_index::*;
+
 mod get_index;
 pub use get_index::*;
 

--- a/src/rest_api/api/indexing/mod.rs
+++ b/src/rest_api/api/indexing/mod.rs
@@ -1,6 +1,9 @@
 mod bulk_index;
 pub use bulk_index::*;
 
+mod bulk_delete;
+pub use bulk_delete::*;
+
 mod create_index;
 pub use create_index::*;
 

--- a/src/rest_api/api/search/identity_search.rs
+++ b/src/rest_api/api/search/identity_search.rs
@@ -49,23 +49,24 @@ pub fn v1_index_search_identity(
     let (query_canon_taut, fingerprint, descriptors) = query_attributes;
 
     let scaffolds = if use_scaffolds {
-        &PARSED_SCAFFOLDS
+        Some(&PARSED_SCAFFOLDS)
     } else {
-        &Vec::new()
+        None
     };
 
-    let matching_scaffolds = if !scaffolds.is_empty() {
-        let scaffold_matches = scaffold_search(&query_canon_taut, scaffolds);
-        match scaffold_matches {
-            Ok(scaffold_matches) => scaffold_matches,
-            Err(e) => {
-                return GetStructureSearchResponse::Err(Json(StructureResponseError {
-                    error: e.to_string(),
-                }))
+    let matching_scaffolds = match scaffolds {
+        Some(scaffolds) => {
+            let scaffold_matches = scaffold_search(&query_canon_taut, scaffolds);
+            match scaffold_matches {
+                Ok(scaffold_matches) => Some(scaffold_matches),
+                Err(e) => {
+                    return GetStructureSearchResponse::Err(Json(StructureResponseError {
+                        error: e.to_string(),
+                    }))
+                }
             }
         }
-    } else {
-        Vec::new()
+        None => None,
     };
 
     let result = identity_search(

--- a/src/rest_api/api/search/substructure_search.rs
+++ b/src/rest_api/api/search/substructure_search.rs
@@ -52,23 +52,24 @@ pub fn v1_index_search_substructure(
     let (query_canon_taut, fingerprint, descriptors) = query_attributes;
 
     let scaffolds = if use_scaffolds {
-        &PARSED_SCAFFOLDS
+        Some(&PARSED_SCAFFOLDS)
     } else {
-        &Vec::new()
+        None
     };
 
-    let matching_scaffolds = if !scaffolds.is_empty() {
-        let scaffold_matches = scaffold_search(&query_canon_taut, scaffolds);
-        match scaffold_matches {
-            Ok(scaffold_matches) => scaffold_matches,
-            Err(e) => {
-                return GetStructureSearchResponse::Err(Json(StructureResponseError {
-                    error: e.to_string(),
-                }))
+    let matching_scaffolds = match scaffolds {
+        Some(scaffolds) => {
+            let scaffold_matches = scaffold_search(&query_canon_taut, scaffolds);
+            match scaffold_matches {
+                Ok(scaffold_matches) => Some(scaffold_matches),
+                Err(e) => {
+                    return GetStructureSearchResponse::Err(Json(StructureResponseError {
+                        error: e.to_string(),
+                    }))
+                }
             }
         }
-    } else {
-        Vec::new()
+        None => None,
     };
 
     let results = substructure_search(
@@ -115,18 +116,21 @@ pub fn v1_index_search_substructure(
 
                 let (taut_fingerprint, taut_descriptors) = taut_attributes;
 
-                let matching_scaffolds = if !scaffolds.is_empty() {
-                    let scaffold_matches = scaffold_search(&test_taut, scaffolds);
-                    match scaffold_matches {
-                        Ok(scaffold_matches) => scaffold_matches,
-                        Err(e) => {
-                            return GetStructureSearchResponse::Err(Json(StructureResponseError {
-                                error: e.to_string(),
-                            }))
+                let matching_scaffolds = match scaffolds {
+                    Some(scaffolds) => {
+                        let scaffold_matches = scaffold_search(&test_taut, scaffolds);
+                        match scaffold_matches {
+                            Ok(scaffold_matches) => Some(scaffold_matches),
+                            Err(e) => {
+                                return GetStructureSearchResponse::Err(Json(
+                                    StructureResponseError {
+                                        error: e.to_string(),
+                                    },
+                                ))
+                            }
                         }
                     }
-                } else {
-                    Vec::new()
+                    None => None,
                 };
 
                 let taut_results = substructure_search(

--- a/src/rest_api/openapi_server.rs
+++ b/src/rest_api/openapi_server.rs
@@ -1,10 +1,11 @@
 use crate::indexing::index_manager::IndexManager;
 use crate::rest_api::api::{
     v1_convert_mol_block_to_smiles, v1_get_index, v1_index_search_basic, v1_index_search_identity,
-    v1_index_search_substructure, v1_list_indexes, v1_list_schemas, v1_post_index,
-    v1_post_index_bulk, v1_standardize, BulkRequest, ConvertedSmilesResponse, GetIndexResponse,
-    GetQuerySearchResponse, GetStructureSearchResponse, ListIndexesResponse, ListSchemasResponse,
-    PostIndexResponse, PostIndexesBulkIndexResponse, StandardizeResponse,
+    v1_index_search_substructure, v1_list_indexes, v1_list_schemas, v1_post_bulk_delete,
+    v1_post_index, v1_post_index_bulk, v1_standardize, BulkRequest, ConvertedSmilesResponse,
+    GetIndexResponse, GetQuerySearchResponse, GetStructureSearchResponse, ListIndexesResponse,
+    ListSchemasResponse, PostIndexResponse, PostIndexesBulkDeleteResponse,
+    PostIndexesBulkIndexResponse, StandardizeResponse,
 };
 use crate::rest_api::models::{MolBlock, Smiles};
 
@@ -143,6 +144,16 @@ impl Api {
         bulk_request: Json<BulkRequest>,
     ) -> PostIndexesBulkIndexResponse {
         v1_post_index_bulk(&self.index_manager, index.to_string(), bulk_request.0).await
+    }
+
+    #[oai(path = "/v1/indexes/:index/bulk_delete", method = "post")]
+    /// Delete a list of smiles (after standardization) from an index
+    pub async fn v1_post_indexes_bulk_delete(
+        &self,
+        index: Path<String>,
+        bulk_request: Json<BulkRequest>,
+    ) -> PostIndexesBulkDeleteResponse {
+        v1_post_bulk_delete(&self.index_manager, index.to_string(), bulk_request.0).await
     }
 
     #[oai(path = "/v1/indexes/:index/search/basic", method = "get")]

--- a/src/rest_api/openapi_server.rs
+++ b/src/rest_api/openapi_server.rs
@@ -1,11 +1,11 @@
 use crate::indexing::index_manager::IndexManager;
 use crate::rest_api::api::{
-    v1_convert_mol_block_to_smiles, v1_delete_index_bulk, v1_get_index, v1_index_search_basic,
-    v1_index_search_identity, v1_index_search_substructure, v1_list_indexes, v1_list_schemas,
-    v1_post_index, v1_post_index_bulk, v1_standardize, BulkRequest, ConvertedSmilesResponse,
-    DeleteIndexesBulkDeleteResponse, GetIndexResponse, GetQuerySearchResponse,
-    GetStructureSearchResponse, ListIndexesResponse, ListSchemasResponse, PostIndexResponse,
-    PostIndexesBulkIndexResponse, StandardizeResponse,
+    v1_convert_mol_block_to_smiles, v1_delete_index, v1_delete_index_bulk, v1_get_index,
+    v1_index_search_basic, v1_index_search_identity, v1_index_search_substructure, v1_list_indexes,
+    v1_list_schemas, v1_post_index, v1_post_index_bulk, v1_standardize, BulkRequest,
+    ConvertedSmilesResponse, DeleteIndexResponse, DeleteIndexesBulkDeleteResponse,
+    GetIndexResponse, GetQuerySearchResponse, GetStructureSearchResponse, ListIndexesResponse,
+    ListSchemasResponse, PostIndexResponse, PostIndexesBulkIndexResponse, StandardizeResponse,
 };
 use crate::rest_api::models::{MolBlock, Smiles};
 
@@ -133,6 +133,12 @@ impl Api {
             schema.0,
             sort_by.0.as_deref(),
         )
+    }
+
+    #[oai(path = "/v1/indexes/:index", method = "delete")]
+    /// Delete an index
+    pub async fn v1_delete_index(&self, index: Path<String>) -> DeleteIndexResponse {
+        v1_delete_index(&self.index_manager, index.to_string())
     }
 
     #[oai(path = "/v1/indexes/:index/bulk_index", method = "post")]

--- a/src/rest_api/openapi_server.rs
+++ b/src/rest_api/openapi_server.rs
@@ -1,10 +1,10 @@
 use crate::indexing::index_manager::IndexManager;
 use crate::rest_api::api::{
-    v1_convert_mol_block_to_smiles, v1_get_index, v1_index_search_basic, v1_index_search_identity,
-    v1_index_search_substructure, v1_list_indexes, v1_list_schemas, v1_post_bulk_delete,
+    v1_convert_mol_block_to_smiles, v1_delete_index_bulk, v1_get_index, v1_index_search_basic,
+    v1_index_search_identity, v1_index_search_substructure, v1_list_indexes, v1_list_schemas,
     v1_post_index, v1_post_index_bulk, v1_standardize, BulkRequest, ConvertedSmilesResponse,
-    GetIndexResponse, GetQuerySearchResponse, GetStructureSearchResponse, ListIndexesResponse,
-    ListSchemasResponse, PostIndexResponse, PostIndexesBulkDeleteResponse,
+    DeleteIndexesBulkDeleteResponse, GetIndexResponse, GetQuerySearchResponse,
+    GetStructureSearchResponse, ListIndexesResponse, ListSchemasResponse, PostIndexResponse,
     PostIndexesBulkIndexResponse, StandardizeResponse,
 };
 use crate::rest_api::models::{MolBlock, Smiles};
@@ -146,14 +146,14 @@ impl Api {
         v1_post_index_bulk(&self.index_manager, index.to_string(), bulk_request.0).await
     }
 
-    #[oai(path = "/v1/indexes/:index/bulk_delete", method = "post")]
+    #[oai(path = "/v1/indexes/:index/bulk_delete", method = "delete")]
     /// Delete a list of smiles (after standardization) from an index
-    pub async fn v1_post_indexes_bulk_delete(
+    pub async fn v1_delete_indexes_bulk_delete(
         &self,
         index: Path<String>,
         bulk_request: Json<BulkRequest>,
-    ) -> PostIndexesBulkDeleteResponse {
-        v1_post_bulk_delete(&self.index_manager, index.to_string(), bulk_request.0).await
+    ) -> DeleteIndexesBulkDeleteResponse {
+        v1_delete_index_bulk(&self.index_manager, index.to_string(), bulk_request.0).await
     }
 
     #[oai(path = "/v1/indexes/:index/search/basic", method = "get")]

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
-use tantivy::schema::{JsonObjectOptions, Schema, SchemaBuilder, FAST, INDEXED, STORED, TEXT};
+use tantivy::schema::{
+    JsonObjectOptions, Schema, SchemaBuilder, FAST, INDEXED, STORED, STRING, TEXT,
+};
 
 use crate::indexing::KNOWN_DESCRIPTORS;
 
@@ -10,7 +12,7 @@ lazy_static::lazy_static! {
 
 fn descriptor_v1_schema() -> Schema {
     let mut builder = SchemaBuilder::new();
-    builder.add_text_field("smiles", TEXT | STORED);
+    builder.add_text_field("smiles", STRING | STORED);
     for field in KNOWN_DESCRIPTORS {
         if field.starts_with("Num") || field.starts_with("lipinski") {
             builder.add_i64_field(field, INDEXED | STORED);

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use tantivy::schema::{JsonObjectOptions, Schema, SchemaBuilder, FAST, STORED, TEXT};
+use tantivy::schema::{JsonObjectOptions, Schema, SchemaBuilder, FAST, INDEXED, STORED, TEXT};
 
 use crate::indexing::KNOWN_DESCRIPTORS;
 
@@ -13,7 +13,7 @@ fn descriptor_v1_schema() -> Schema {
     builder.add_text_field("smiles", TEXT | STORED);
     for field in KNOWN_DESCRIPTORS {
         if field.starts_with("Num") || field.starts_with("lipinski") {
-            builder.add_i64_field(field, FAST | STORED);
+            builder.add_i64_field(field, INDEXED | STORED);
         } else {
             builder.add_f64_field(field, FAST | STORED);
         }

--- a/src/search/identity_search.rs
+++ b/src/search/identity_search.rs
@@ -18,7 +18,7 @@ pub fn identity_search(
 ) -> eyre::Result<Option<DocAddress>> {
     let schema = searcher.schema();
 
-    let query = build_query(query_descriptors, extra_query, scaffold_matches);
+    let query = build_identity_query(query_descriptors, extra_query, scaffold_matches);
 
     // Note: default to a large number of possible results to ensure we don't miss the molecule
     let tantivy_limit = 10_000;
@@ -58,7 +58,7 @@ pub fn identity_search(
     Ok(None)
 }
 
-pub fn build_query(
+pub fn build_identity_query(
     descriptors: &HashMap<String, f64>,
     extra_query: &str,
     matching_scaffolds: &Option<Vec<u64>>,
@@ -104,7 +104,7 @@ mod tests {
     #[test]
     fn test_build_query() {
         let descriptors: HashMap<_, _> = [("NumAtoms".to_string(), 10.0)].into_iter().collect();
-        let query = super::build_query(&descriptors, &"".to_string(), &None);
+        let query = super::build_identity_query(&descriptors, &"".to_string(), &None);
         assert_eq!(query, "NumAtoms:[10 TO 10]");
     }
 

--- a/src/search/identity_search.rs
+++ b/src/search/identity_search.rs
@@ -95,7 +95,7 @@ mod tests {
 
     use tantivy::{
         doc,
-        schema::{SchemaBuilder, FAST, STORED, TEXT},
+        schema::{SchemaBuilder, FAST, INDEXED, STORED, STRING},
         IndexBuilder,
     };
 
@@ -116,7 +116,7 @@ mod tests {
 
         let mut builder = SchemaBuilder::new();
 
-        let smiles_field = builder.add_text_field("smiles", TEXT | STORED);
+        let smiles_field = builder.add_text_field("smiles", STRING | STORED);
         let fingerprint_field = builder.add_bytes_field("fingerprint", FAST | STORED);
 
         let mut doc = doc!(
@@ -126,7 +126,7 @@ mod tests {
 
         for (descriptor, val) in &query_descriptors {
             if descriptor.starts_with("Num") || descriptor.starts_with("lipinski") {
-                let current_field = builder.add_i64_field(descriptor, FAST | STORED);
+                let current_field = builder.add_i64_field(descriptor, INDEXED | STORED);
 
                 doc.add_field_value(current_field, *val as i64);
             } else {

--- a/src/search/identity_search.rs
+++ b/src/search/identity_search.rs
@@ -11,12 +11,13 @@ use crate::search::{basic_search::basic_search, STRUCTURE_MATCH_DESCRIPTORS};
 pub fn identity_search(
     searcher: &Searcher,
     query_mol: &ROMol,
-    scaffold_matches: &Vec<u64>,
+    scaffold_matches: &Option<Vec<u64>>,
     query_fingerprint: &BitSlice<u8, Lsb0>,
     query_descriptors: &HashMap<String, f64>,
     extra_query: &str,
 ) -> eyre::Result<Option<DocAddress>> {
     let schema = searcher.schema();
+
     let query = build_query(query_descriptors, extra_query, scaffold_matches);
 
     // Note: default to a large number of possible results to ensure we don't miss the molecule
@@ -60,7 +61,7 @@ pub fn identity_search(
 pub fn build_query(
     descriptors: &HashMap<String, f64>,
     extra_query: &str,
-    matching_scaffolds: &Vec<u64>,
+    matching_scaffolds: &Option<Vec<u64>>,
 ) -> String {
     let mut query_parts = Vec::with_capacity(descriptors.len());
 
@@ -70,8 +71,10 @@ pub fn build_query(
         }
     }
 
-    for s in matching_scaffolds {
-        query_parts.push(format!("extra_data.scaffolds:{s}"))
+    if let Some(scaffolds) = matching_scaffolds {
+        for s in scaffolds {
+            query_parts.push(format!("extra_data.scaffolds:{s}"))
+        }
     }
 
     for (k, v) in descriptors {
@@ -101,7 +104,7 @@ mod tests {
     #[test]
     fn test_build_query() {
         let descriptors: HashMap<_, _> = [("NumAtoms".to_string(), 10.0)].into_iter().collect();
-        let query = super::build_query(&descriptors, &"".to_string(), &Vec::new());
+        let query = super::build_query(&descriptors, &"".to_string(), &None);
         assert_eq!(query, "NumAtoms:[10 TO 10]");
     }
 
@@ -151,7 +154,7 @@ mod tests {
         let result = super::identity_search(
             &searcher,
             &query_mol,
-            &Vec::new(),
+            &None,
             query_fingerprint.0.as_bitslice(),
             &query_descriptors,
             &extra_query,

--- a/src/search/identity_search.rs
+++ b/src/search/identity_search.rs
@@ -57,7 +57,7 @@ pub fn identity_search(
     Ok(None)
 }
 
-fn build_query(
+pub fn build_query(
     descriptors: &HashMap<String, f64>,
     extra_query: &str,
     matching_scaffolds: &Vec<u64>,

--- a/src/search/substructure_search.rs
+++ b/src/search/substructure_search.rs
@@ -13,7 +13,7 @@ use crate::search::{
 pub fn substructure_search(
     searcher: &Searcher,
     query_mol: &ROMol,
-    scaffold_matches: &Vec<u64>,
+    scaffold_matches: &Option<Vec<u64>>,
     query_fingerprint: &BitSlice<u8, Lsb0>,
     query_descriptors: &HashMap<String, f64>,
     result_limit: usize,
@@ -71,7 +71,7 @@ pub fn substructure_search(
 fn build_query(
     descriptors: &HashMap<String, f64>,
     extra_query: &str,
-    matching_scaffolds: &Vec<u64>,
+    matching_scaffolds: &Option<Vec<u64>>,
 ) -> String {
     let mut query_parts = Vec::with_capacity(descriptors.len());
 
@@ -81,8 +81,10 @@ fn build_query(
         }
     }
 
-    for s in matching_scaffolds {
-        query_parts.push(format!("extra_data.scaffolds:{s}"))
+    if let Some(scaffolds) = matching_scaffolds {
+        for s in scaffolds {
+            query_parts.push(format!("extra_data.scaffolds:{s}"))
+        }
     }
 
     for (k, v) in descriptors {
@@ -112,7 +114,7 @@ mod tests {
     #[test]
     fn test_build_query() {
         let descriptors: HashMap<_, _> = [("NumAtoms".to_string(), 10.0)].into_iter().collect();
-        let query = super::build_query(&descriptors, &"".to_string(), &Vec::new());
+        let query = super::build_query(&descriptors, &"".to_string(), &None);
         assert_eq!(query, "NumAtoms:[10 TO 10000]");
     }
 
@@ -163,7 +165,7 @@ mod tests {
         let results = super::substructure_search(
             &searcher,
             &query_mol,
-            &Vec::new(),
+            &None,
             query_fingerprint.0.as_bitslice(),
             &query_descriptors,
             10,

--- a/src/search/substructure_search.rs
+++ b/src/search/substructure_search.rs
@@ -20,7 +20,7 @@ pub fn substructure_search(
     extra_query: &str,
 ) -> eyre::Result<HashSet<DocAddress>> {
     let schema = searcher.schema();
-    let query = build_query(query_descriptors, extra_query, scaffold_matches);
+    let query = build_substructure_query(query_descriptors, extra_query, scaffold_matches);
 
     // Note: in the end, we want a limit for the FINAL number of matches to return
     let tantivy_limit = 10 * result_limit;
@@ -68,7 +68,7 @@ pub fn substructure_search(
     Ok(filtered_results2)
 }
 
-fn build_query(
+fn build_substructure_query(
     descriptors: &HashMap<String, f64>,
     extra_query: &str,
     matching_scaffolds: &Option<Vec<u64>>,
@@ -114,7 +114,7 @@ mod tests {
     #[test]
     fn test_build_query() {
         let descriptors: HashMap<_, _> = [("NumAtoms".to_string(), 10.0)].into_iter().collect();
-        let query = super::build_query(&descriptors, &"".to_string(), &None);
+        let query = super::build_substructure_query(&descriptors, &"".to_string(), &None);
         assert_eq!(query, "NumAtoms:[10 TO 10000]");
     }
 

--- a/src/search/substructure_search.rs
+++ b/src/search/substructure_search.rs
@@ -105,7 +105,7 @@ mod tests {
 
     use tantivy::{
         doc,
-        schema::{SchemaBuilder, FAST, STORED, TEXT},
+        schema::{SchemaBuilder, FAST, INDEXED, STORED, STRING},
         IndexBuilder,
     };
 
@@ -127,7 +127,7 @@ mod tests {
 
         let mut builder = SchemaBuilder::new();
 
-        let smiles_field = builder.add_text_field("smiles", TEXT | STORED);
+        let smiles_field = builder.add_text_field("smiles", STRING | STORED);
         let fingerprint_field = builder.add_bytes_field("fingerprint", FAST | STORED);
 
         let mut doc = doc!(
@@ -137,7 +137,7 @@ mod tests {
 
         for (descriptor, val) in &query_descriptors {
             if descriptor.starts_with("Num") || descriptor.starts_with("lipinski") {
-                let current_field = builder.add_i64_field(descriptor, FAST | STORED);
+                let current_field = builder.add_i64_field(descriptor, INDEXED | STORED);
 
                 doc.add_field_value(current_field, *val as i64);
             } else {


### PR DESCRIPTION
**Description**
Resolves [#74](https://github.com/rdkit-rs/cheminee/issues/74) and [#75](https://github.com/rdkit-rs/cheminee/issues/75) by adding `bulk-delete` and `delete-index` endpoints.

Given an index and a list of smiles (packaged in a BulkRequestDoc), the `bulk-delete` API endpoint will standardize the input smiles, then delete the corresponding compounds from the specified index. The CLI version takes a comma-delimited list of smiles. 

Note: for bulk indexing, detecting and removing duplicates is a pain and slows down performance. Therefore, if the user desires to update any compound records, they should:
1) use `bulk-delete` to remove the smiles that are to be updated, then 
2) use `bulk-index` to index the updated records.

Given an index, the 'delete-index' endpoint will...delete an index.
