### PR TITLE
Smiles-to-molblock endpoint

### DIFF
--- a/src/rest_api/api/compound_processing/convert_smiles_to_mol_block.rs
+++ b/src/rest_api/api/compound_processing/convert_smiles_to_mol_block.rs
@@ -1,0 +1,43 @@
+use crate::rest_api::models::Smiles;
+use poem_openapi::payload::Json;
+use poem_openapi_derive::{ApiResponse, Object};
+use rayon::prelude::*;
+use rdkit::ROMol;
+
+#[derive(ApiResponse)]
+pub enum ConvertedMolBlockResponse {
+    #[oai(status = "200")]
+    Ok(Json<Vec<ConvertedMolBlock>>),
+}
+
+#[derive(Object, Debug)]
+pub struct ConvertedMolBlock {
+    #[oai(skip_serializing_if_is_none)]
+    pub mol_block: Option<String>,
+    #[oai(skip_serializing_if_is_none)]
+    pub error: Option<String>,
+}
+
+pub async fn v1_convert_smiles_to_mol_block(
+    smiles_vec: Json<Vec<Smiles>>,
+) -> ConvertedMolBlockResponse {
+    let mol_blocks = smiles_vec
+        .0
+        .into_par_iter()
+        .map(|s| {
+            let ro_mol = ROMol::from_smiles(&s.smiles);
+
+            let (mol_block, error) = match ro_mol {
+                Ok(ro_mol) => (Some(ro_mol.to_molblock()), None),
+                Err(_) => (
+                    None,
+                    Some(format!("Could not convert smiles\n{}\n", s.smiles)),
+                ),
+            };
+
+            ConvertedMolBlock { mol_block, error }
+        })
+        .collect::<Vec<_>>();
+
+    ConvertedMolBlockResponse::Ok(Json(mol_blocks))
+}

--- a/src/rest_api/api/compound_processing/mod.rs
+++ b/src/rest_api/api/compound_processing/mod.rs
@@ -4,5 +4,8 @@ pub use compound_processing_management::*;
 mod convert_mol_block_to_smiles;
 pub use convert_mol_block_to_smiles::*;
 
+mod convert_smiles_to_mol_block;
+pub use convert_smiles_to_mol_block::*;
+
 mod standardize;
 pub use standardize::*;

--- a/src/rest_api/api/compound_processing/standardize.rs
+++ b/src/rest_api/api/compound_processing/standardize.rs
@@ -4,12 +4,12 @@ use poem_openapi::payload::Json;
 use rayon::prelude::*;
 
 pub async fn v1_standardize(
-    mol: Json<Vec<Smiles>>,
+    smiles_vec: Json<Vec<Smiles>>,
     attempt_fix: Option<&str>,
 ) -> StandardizeResponse {
     let attempt_fix = attempt_fix.is_some();
 
-    let standardized_smiles = mol
+    let standardized_smiles = smiles_vec
         .0
         .into_par_iter()
         .map(|s| {

--- a/src/rest_api/openapi_server.rs
+++ b/src/rest_api/openapi_server.rs
@@ -1,8 +1,9 @@
 use crate::indexing::index_manager::IndexManager;
 use crate::rest_api::api::{
-    v1_convert_mol_block_to_smiles, v1_delete_index, v1_delete_index_bulk, v1_get_index,
-    v1_index_search_basic, v1_index_search_identity, v1_index_search_substructure, v1_list_indexes,
-    v1_list_schemas, v1_post_index, v1_post_index_bulk, v1_standardize, BulkRequest,
+    v1_convert_mol_block_to_smiles, v1_convert_smiles_to_mol_block, v1_delete_index,
+    v1_delete_index_bulk, v1_get_index, v1_index_search_basic, v1_index_search_identity,
+    v1_index_search_substructure, v1_list_indexes, v1_list_schemas, v1_post_index,
+    v1_post_index_bulk, v1_standardize, BulkRequest, ConvertedMolBlockResponse,
     ConvertedSmilesResponse, DeleteIndexResponse, DeleteIndexesBulkDeleteResponse,
     GetIndexResponse, GetQuerySearchResponse, GetStructureSearchResponse, ListIndexesResponse,
     ListSchemasResponse, PostIndexResponse, PostIndexesBulkIndexResponse, StandardizeResponse,
@@ -91,13 +92,22 @@ impl Api {
     }
 
     #[oai(path = "/v1/convert/mol_block_to_smiles", method = "post")]
-    /// Pass a list of SMILES through fragment_parent, uncharger, and canonicalization routines
+    /// Convert a list of SMILES to molblocks
     pub async fn v1_convert_mol_block_to_smiles(
         &self,
         sanitize: Query<String>,
-        mol: Json<Vec<MolBlock>>,
+        mol_blocks: Json<Vec<MolBlock>>,
     ) -> ConvertedSmilesResponse {
-        v1_convert_mol_block_to_smiles(sanitize.0, mol).await
+        v1_convert_mol_block_to_smiles(sanitize.0, mol_blocks).await
+    }
+
+    #[oai(path = "/v1/convert/smiles_to_mol_block", method = "post")]
+    /// Convert a list of molblocks to SMILES
+    pub async fn v1_convert_smiles_to_mol_block(
+        &self,
+        smiles_vec: Json<Vec<Smiles>>,
+    ) -> ConvertedMolBlockResponse {
+        v1_convert_smiles_to_mol_block(smiles_vec).await
     }
 
     #[oai(path = "/v1/schemas", method = "get")]


### PR DESCRIPTION
**Description**
Resolves [#84](https://github.com/rdkit-rs/cheminee/issues/84) by introducing a `smiles-to-molblock` API endpoint. Now users can submit an array of compound smiles, and the endpoint will attempt to convert each input smiles into a molblock.

Also made some minor changes to other the compound processing endpoints (e.g. for greater interpretability).
