### PR TITLE
Println is now illegal

### DIFF
--- a/src/command_line/indexing/bulk_delete.rs
+++ b/src/command_line/indexing/bulk_delete.rs
@@ -48,8 +48,8 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
             Ok(parsed_query) => {
                 let delete_operation = deleter.delete_query(parsed_query);
                 match delete_operation {
-                    Ok(_) => println!("Deleting \"{}\"", smiles),
-                    Err(e) => println!("Failed to delete \"{}\": {}", smiles, e),
+                    Ok(_) => log::info!("Deleting \"{}\"", smiles),
+                    Err(e) => log::info!("Failed to delete \"{}\": {}", smiles, e),
                 }
             }
             Err(e) => println!("Failed to construct delete query for \"{}\": {}", smiles, e),

--- a/src/command_line/indexing/bulk_delete.rs
+++ b/src/command_line/indexing/bulk_delete.rs
@@ -52,7 +52,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
                     Err(e) => log::info!("Failed to delete \"{}\": {}", smiles, e),
                 }
             }
-            Err(e) => println!("Failed to construct delete query for \"{}\": {}", smiles, e),
+            Err(e) => log::info!("Failed to construct delete query for \"{}\": {}", smiles, e),
         }
     }
 

--- a/src/command_line/indexing/bulk_index.rs
+++ b/src/command_line/indexing/bulk_index.rs
@@ -80,12 +80,12 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
                             match write_operation {
                                 Ok(_) => (),
                                 Err(e) => {
-                                    println!("Failed doc creation: {:?}", e);
+                                    log::info!("Failed doc creation: {:?}", e);
                                 }
                             }
                         }
                         Err(e) => {
-                            println!("Failed doc creation: {:?}", e);
+                            log::info!("Failed doc creation: {:?}", e);
                         }
                     }
                 })

--- a/src/command_line/indexing/create_index.rs
+++ b/src/command_line/indexing/create_index.rs
@@ -52,6 +52,6 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         sort_by.map(|s| s.as_str()),
     )?;
 
-    println!("New index created at {}", index_path);
+    log::info!("New index created at {}", index_path);
     Ok(())
 }

--- a/src/command_line/indexing/delete_index.rs
+++ b/src/command_line/indexing/delete_index.rs
@@ -24,6 +24,6 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
     let index_manager = IndexManager::new(storage_dir, false)?;
     index_manager.delete(index_name.deref())?;
 
-    println!("Deleted index {}", index_path);
+    log::info!("Deleted index {}", index_path);
     Ok(())
 }

--- a/src/command_line/indexing/index_sdf.rs
+++ b/src/command_line/indexing/index_sdf.rs
@@ -141,7 +141,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<usize> {
 
         if counter > 0 && counter % 10_000 == 0 {
             index_writer.commit()?;
-            println!("{:?} compounds written so far", counter);
+            log::info!("{:?} compounds written so far", counter);
         }
 
         counter += 1;

--- a/src/command_line/pubchem/stream_pubchem_sdf.rs
+++ b/src/command_line/pubchem/stream_pubchem_sdf.rs
@@ -40,7 +40,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         }
     }
 
-    println!("successes: {}, errors: {}", success_count, error_count);
+    log::info!("successes: {}, errors: {}", success_count, error_count);
 
     Ok(())
 }

--- a/src/command_line/search/basic_search.rs
+++ b/src/command_line/search/basic_search.rs
@@ -50,7 +50,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
     let results = basic_search(&searcher, query, limit)?;
     let final_results = aggregate_query_hits(searcher, results, query)?;
 
-    println!("{:#?}", final_results);
+    log::info!("{:#?}", final_results);
 
     Ok(())
 }

--- a/src/command_line/search/cli_structure_search.rs
+++ b/src/command_line/search/cli_structure_search.rs
@@ -101,9 +101,9 @@ pub fn cli_structure_search(method: &str, matches: &ArgMatches) -> eyre::Result<
     let final_results = aggregate_search_hits(searcher, results, used_tautomers, smiles)?;
 
     if final_results.len() > result_limit {
-        println!("{:#?}", &final_results[..result_limit]);
+        log::info!("{:#?}", &final_results[..result_limit]);
     } else {
-        println!("{:#?}", final_results)
+        log::info!("{:#?}", final_results)
     }
 
     Ok(())

--- a/src/command_line/search/identity_search.rs
+++ b/src/command_line/search/identity_search.rs
@@ -93,7 +93,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         let (smiles, extra_data) =
             get_smiles_and_extra_data(result, &searcher, smiles_field, extra_data_field)?;
 
-        println!(
+        log::info!(
             "{:#?}",
             &[StructureSearchHit {
                 extra_data,
@@ -104,7 +104,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
             }]
         );
     } else {
-        println!("No exact match result for {:?}", query_smiles);
+        log::info!("No exact match result for {:?}", query_smiles);
     }
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::print_stdout)]
+
 pub mod command_line;
 pub mod indexing;
 pub mod pubchem;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::print_stdout)]
+
 use cheminee::{command_line, rest_api};
 use clap::*;
 

--- a/src/pubchem/fetch.rs
+++ b/src/pubchem/fetch.rs
@@ -31,7 +31,7 @@ pub async fn down_all_current_sdf(p: impl AsRef<Path>) -> eyre::Result<()> {
 
     let current_dir = std::env::current_dir().unwrap();
     for capture in captures {
-        println!("working on {}", capture);
+        log::info!("working on {}", capture);
         let mut output_file = tokio::fs::File::create(current_dir.join(&p).join(capture))
             .await
             .unwrap();

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -6,7 +6,7 @@ use poem::{handler, Route};
 use poem_openapi::param::{Path, Query};
 use poem_openapi::payload::Json;
 
-const MOL_BLOCK: &'static str = r#"
+const MOL_BLOCK: &str = r#"
   -OEChem-05172223082D
 
  31 30  0     1  0  0  0  0  0999 V2000

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -16,21 +16,21 @@ use tantivy::{
 #[test]
 fn test_build_identity_query() {
     let descriptors: HashMap<_, _> = [("NumAtoms".to_string(), 10.0)].into_iter().collect();
-    let query = build_identity_query(&descriptors, &"".to_string(), &None);
+    let query = build_identity_query(&descriptors, "", &None);
     assert_eq!(query, "NumAtoms:[10 TO 10]");
 }
 
 #[test]
 fn test_build_substructure_query() {
     let descriptors: HashMap<_, _> = [("NumAtoms".to_string(), 10.0)].into_iter().collect();
-    let query = build_substructure_query(&descriptors, &"".to_string(), &None);
+    let query = build_substructure_query(&descriptors, "", &None);
     assert_eq!(query, "NumAtoms:[10 TO 10000]");
 }
 
 #[test]
 fn test_build_superstructure_query() {
     let descriptors: HashMap<_, _> = [("NumAtoms".to_string(), 10.0)].into_iter().collect();
-    let query = build_superstructure_query(&descriptors, &"".to_string(), &Some(vec![0, 1]));
+    let query = build_superstructure_query(&descriptors, "", &Some(vec![0, 1]));
     assert_eq!(
         query,
         "NumAtoms:[0 TO 10] AND (extra_data.scaffolds:0 OR extra_data.scaffolds:1 OR extra_data.scaffolds:-1)"


### PR DESCRIPTION
Lets push ourselves to get good at log::info/log::debug and friends.

This lint disables `println!()`. The following code will fail to compile:

```
pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
    println!("meow");
    let index_path = matches
        .get_one::<String>("index")
        .ok_or(eyre::eyre!("Failed to extract index path"))?;
```

with the compiler saying:

```
% cargo clippy 
    Checking cheminee v0.1.27 (/Users/xlange/code/assaydepot/cheminee)
error: use of `println!`
  --> src/command_line/search/basic_search.rs:32:5
   |
32 |     println!("meow");
   |     ^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#print_stdout
note: the lint level is defined here
  --> src/lib.rs:1:9
   |
1  | #![deny(clippy::print_stdout)]
   |         ^^^^^^^^^^^^^^^^^^^^

error: could not compile `cheminee` (lib) due to 1 previous error
```