### PR TITLE
Fix param defaults for reading molblocks in index-sdf action

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Testing in Docker
 
 Run the Cheminée image in a docker container:
 
-    docker run --rm -dt -p 4001:4001 --name cheminee ghcr.io/rdkit-rs/cheminee:0.1.29
+    docker run --rm -dt -p 4001:4001 --name cheminee ghcr.io/rdkit-rs/cheminee:0.1.30
 
 Exec into the container:
 

--- a/src/command_line/indexing/index_sdf.rs
+++ b/src/command_line/indexing/index_sdf.rs
@@ -60,7 +60,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
     }
     std::fs::create_dir(index_dir)?;
 
-    let mol_iter = MolBlockIter::from_gz_file(sdf_path, false, false, false)
+    let mol_iter = MolBlockIter::from_gz_file(sdf_path, true, true, false)
         .map_err(|e| eyre::eyre!("could not read gz file: {:?}", e))?;
 
     let mol_iter: Box<dyn Iterator<Item = Result<RWMol, String>>> = if let Some(limit) = limit {


### PR DESCRIPTION
Resolves [#97](https://github.com/rdkit-rs/cheminee/issues/97). We are now setting `sanitize=true, remove_hs=true, strict_parse=false` when building RWMols from molblocks in the `index-sdf` CLI action.