### PR TITLE
Fix identity search query building

### DIFF
--- a/src/search/identity_search.rs
+++ b/src/search/identity_search.rs
@@ -84,7 +84,7 @@ pub fn build_identity_query(
         if STRUCTURE_MATCH_DESCRIPTORS.contains(&k.as_str()) {
             let re = Regex::new(&format!("{k}:")).unwrap();
             if !re.is_match(extra_query) {
-                query_parts.push(format!("{k}:[{v} TO {v}]"));
+                query_parts.push(format!("{k}:{v}"));
             }
         }
     }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -20,7 +20,7 @@ pub struct StructureValidationError {
     pub error: String,
 }
 
-pub const STRUCTURE_MATCH_DESCRIPTORS: [&str; 20] = [
+pub const STRUCTURE_MATCH_DESCRIPTORS: [&str; 19] = [
     "NumAliphaticHeterocycles",
     "NumAliphaticRings",
     "NumAmideBonds",
@@ -39,7 +39,6 @@ pub const STRUCTURE_MATCH_DESCRIPTORS: [&str; 20] = [
     "NumSaturatedRings",
     "NumSpiroAtoms",
     "NumUnspecifiedAtomStereoCenters",
-    "exactmw",
     "lipinskiHBA",
 ];
 

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -17,7 +17,7 @@ use tantivy::{
 fn test_build_identity_query() {
     let descriptors: HashMap<_, _> = [("NumAtoms".to_string(), 10.0)].into_iter().collect();
     let query = build_identity_query(&descriptors, "", &None);
-    assert_eq!(query, "NumAtoms:[10 TO 10]");
+    assert_eq!(query, "NumAtoms:10");
 }
 
 #[test]


### PR DESCRIPTION
Resolves [#100](https://github.com/rdkit-rs/cheminee/issues/100). 

We were doing two things:
1) We were trying to use range queries for comparing exact numbers of indexed structure match fields (e.g. "NumAtoms:[10 TO 10]" instead of the more appropriate exact query search (e.g. "NumAtoms:10").
2) We were using "exactmw" as a structure match field. This descriptor is not an integer, might slow down the search, and wasn't playing nice with the `identity-search` endpoint.