### PR TITLE
Add option to account for chirality for structure searches

### DIFF
--- a/src/command_line/search/cli_structure_search.rs
+++ b/src/command_line/search/cli_structure_search.rs
@@ -12,10 +12,17 @@ pub fn cli_structure_search(method: &str, matches: &ArgMatches) -> eyre::Result<
     let smiles = matches
         .get_one::<String>("smiles")
         .ok_or(eyre::eyre!("Failed to extract SMILES"))?;
+    let use_chirality = matches.get_one::<String>("use-chirality");
     let result_limit = matches.get_one::<String>("result-limit");
     let tautomer_limit = matches.get_one::<String>("tautomer-limit");
     let extra_query = matches.get_one::<String>("extra-query");
     let use_scaffolds = matches.get_one::<String>("use-scaffolds");
+
+    let use_chirality = if let Some(use_chirality) = use_chirality {
+        !matches!(use_chirality.as_str(), "false")
+    } else {
+        false
+    };
 
     let result_limit = if let Some(result_limit) = result_limit {
         result_limit.parse::<usize>()?
@@ -59,6 +66,7 @@ pub fn cli_structure_search(method: &str, matches: &ArgMatches) -> eyre::Result<
         method,
         use_scaffolds,
         result_limit,
+        use_chirality,
         &extra_query,
     )?;
 
@@ -80,6 +88,7 @@ pub fn cli_structure_search(method: &str, matches: &ArgMatches) -> eyre::Result<
                         method,
                         use_scaffolds,
                         result_limit,
+                        use_chirality,
                         &extra_query,
                     )
                     .ok()

--- a/src/command_line/search/identity_search.rs
+++ b/src/command_line/search/identity_search.rs
@@ -24,6 +24,14 @@ pub fn command() -> Command {
                 .num_args(1),
         )
         .arg(
+            Arg::new("use-chirality")
+                .required(false)
+                .long("use-chirality")
+                .short('c')
+                .help("Indicates whether chirality should be taken into account for the search")
+                .num_args(1),
+        )
+        .arg(
             Arg::new("extra-query")
                 .required(false)
                 .long("extra-query")
@@ -48,8 +56,16 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
     let query_smiles = matches
         .get_one::<String>("smiles")
         .ok_or(eyre::eyre!("Failed to extract SMILES"))?;
+    let use_chirality = matches.get_one::<String>("use-chirality");
     let extra_query = matches.get_one::<String>("extra-query");
     let use_scaffolds = matches.get_one::<String>("use-scaffolds");
+
+    // by default, we will ignore chirality
+    let use_chirality = if let Some(use_chirality) = use_chirality {
+        !matches!(use_chirality.as_str(), "false")
+    } else {
+        false
+    };
 
     let extra_query = if let Some(extra_query) = extra_query {
         extra_query.clone()
@@ -82,6 +98,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         &matching_scaffolds,
         fingerprint.0.as_bitslice(),
         &descriptors,
+        use_chirality,
         &extra_query,
     )?;
 

--- a/src/command_line/search/substructure_search.rs
+++ b/src/command_line/search/substructure_search.rs
@@ -20,6 +20,14 @@ pub fn command() -> Command {
                 .num_args(1),
         )
         .arg(
+            Arg::new("use-chirality")
+                .required(false)
+                .long("use-chirality")
+                .short('c')
+                .help("Indicates whether chirality should be taken into account for the search")
+                .num_args(1),
+        )
+        .arg(
             Arg::new("result-limit")
                 .required(false)
                 .long("result-limit")

--- a/src/command_line/search/superstructure_search.rs
+++ b/src/command_line/search/superstructure_search.rs
@@ -20,6 +20,14 @@ pub fn command() -> Command {
                 .num_args(1),
         )
         .arg(
+            Arg::new("use-chirality")
+                .required(false)
+                .long("use-chirality")
+                .short('c')
+                .help("Indicates whether chirality should be taken into account for the search")
+                .num_args(1),
+        )
+        .arg(
             Arg::new("result-limit")
                 .required(false)
                 .long("result-limit")

--- a/src/rest_api/api/search/identity_search.rs
+++ b/src/rest_api/api/search/identity_search.rs
@@ -11,6 +11,7 @@ pub fn v1_index_search_identity(
     index_manager: &IndexManager,
     index: String,
     query_smiles: String,
+    use_chirality: bool,
     extra_query: &str,
     use_scaffolds: bool,
 ) -> GetStructureSearchResponse {
@@ -60,6 +61,7 @@ pub fn v1_index_search_identity(
         &matching_scaffolds,
         fingerprint.0.as_bitslice(),
         &descriptors,
+        use_chirality,
         extra_query,
     );
 

--- a/src/rest_api/api/search/identity_search.rs
+++ b/src/rest_api/api/search/identity_search.rs
@@ -2,8 +2,7 @@ use crate::indexing::index_manager::IndexManager;
 use crate::rest_api::api::{GetStructureSearchResponse, StructureResponseError};
 use crate::search::scaffold_search::{scaffold_search, PARSED_SCAFFOLDS};
 use crate::search::{
-    get_smiles_and_extra_data, identity_search::identity_search, prepare_query_structure,
-    StructureSearchHit,
+    aggregate_search_hits, identity_search::identity_search, prepare_query_structure,
 };
 use poem_openapi::payload::Json;
 
@@ -55,7 +54,7 @@ pub fn v1_index_search_identity(
         None
     };
 
-    let result = identity_search(
+    let results = identity_search(
         &searcher,
         &query_canon_taut,
         &matching_scaffolds,
@@ -65,27 +64,25 @@ pub fn v1_index_search_identity(
         extra_query,
     );
 
-    match result {
-        Ok(Some(result)) => {
-            let schema = searcher.schema();
-            let smiles_field = schema.get_field("smiles").unwrap();
-            let extra_data_field = schema.get_field("extra_data").unwrap();
-
-            let (smiles, extra_data) =
-                get_smiles_and_extra_data(result, &searcher, smiles_field, extra_data_field)
-                    .unwrap();
-
-            GetStructureSearchResponse::Ok(Json(vec![StructureSearchHit {
-                extra_data,
-                smiles,
-                score: 1.0,
-                query: query_smiles,
-                used_tautomers: false,
-            }]))
+    let results = match results {
+        Ok(results) => results,
+        Err(e) => {
+            return GetStructureSearchResponse::Err(Json(StructureResponseError {
+                error: e.to_string(),
+            }))
         }
-        Ok(None) => GetStructureSearchResponse::Ok(Json(Vec::new())),
-        Err(e) => GetStructureSearchResponse::Err(Json(StructureResponseError {
-            error: e.to_string(),
-        })),
-    }
+    };
+
+    let final_results = aggregate_search_hits(searcher, results, false, &query_smiles);
+
+    let final_results = match final_results {
+        Ok(final_results) => final_results,
+        Err(e) => {
+            return GetStructureSearchResponse::Err(Json(StructureResponseError {
+                error: e.to_string(),
+            }))
+        }
+    };
+
+    GetStructureSearchResponse::Ok(Json(final_results))
 }

--- a/src/rest_api/api/search/structure_search.rs
+++ b/src/rest_api/api/search/structure_search.rs
@@ -13,6 +13,7 @@ use tantivy::Index;
 pub fn v1_index_search_structure(
     index: eyre::Result<Index>,
     smiles: String,
+    use_chirality: bool,
     method: &str,
     result_limit: usize,
     tautomer_limit: usize,
@@ -68,6 +69,7 @@ pub fn v1_index_search_structure(
         method,
         use_scaffolds,
         result_limit,
+        use_chirality,
         extra_query,
     );
 
@@ -98,6 +100,7 @@ pub fn v1_index_search_structure(
                         method,
                         use_scaffolds,
                         result_limit,
+                        use_chirality,
                         extra_query,
                     )
                     .ok()

--- a/src/rest_api/openapi_server.rs
+++ b/src/rest_api/openapi_server.rs
@@ -195,11 +195,19 @@ impl Api {
         &self,
         index: Path<String>,
         smiles: Query<String>,
+        use_chirality: Query<Option<String>>,
         result_limit: Query<Option<usize>>,
         tautomer_limit: Query<Option<usize>>,
         extra_query: Query<Option<String>>,
         use_scaffolds: Query<Option<String>>,
     ) -> GetStructureSearchResponse {
+        // by default, we will ignore chirality
+        let use_chirality = if let Some(use_chirality) = use_chirality.0 {
+            !matches!(use_chirality.as_str(), "false")
+        } else {
+            false
+        };
+
         let result_limit = if let Some(result_limit) = result_limit.0 {
             result_limit
         } else {
@@ -230,6 +238,7 @@ impl Api {
         v1_index_search_structure(
             index,
             smiles.0,
+            use_chirality,
             "substructure",
             result_limit,
             tautomer_limit,
@@ -244,11 +253,19 @@ impl Api {
         &self,
         index: Path<String>,
         smiles: Query<String>,
+        use_chirality: Query<Option<String>>,
         result_limit: Query<Option<usize>>,
         tautomer_limit: Query<Option<usize>>,
         extra_query: Query<Option<String>>,
         use_scaffolds: Query<Option<String>>,
     ) -> GetStructureSearchResponse {
+        // by default, we will ignore chirality
+        let use_chirality = if let Some(use_chirality) = use_chirality.0 {
+            !matches!(use_chirality.as_str(), "false")
+        } else {
+            false
+        };
+
         let result_limit = if let Some(result_limit) = result_limit.0 {
             result_limit
         } else {
@@ -279,6 +296,7 @@ impl Api {
         v1_index_search_structure(
             index,
             smiles.0,
+            use_chirality,
             "superstructure",
             result_limit,
             tautomer_limit,
@@ -293,9 +311,17 @@ impl Api {
         &self,
         index: Path<String>,
         smiles: Query<String>,
+        use_chirality: Query<Option<String>>,
         extra_query: Query<Option<String>>,
         use_scaffolds: Query<Option<String>>,
     ) -> GetStructureSearchResponse {
+        // by default, we will ignore chirality
+        let use_chirality = if let Some(use_chirality) = use_chirality.0 {
+            !matches!(use_chirality.as_str(), "false")
+        } else {
+            false
+        };
+
         let extra_query = if let Some(extra_query) = extra_query.0 {
             extra_query
         } else {
@@ -313,6 +339,7 @@ impl Api {
             &self.index_manager,
             index.to_string(),
             smiles.0,
+            use_chirality,
             &extra_query,
             use_scaffolds,
         )

--- a/src/search/identity_search.rs
+++ b/src/search/identity_search.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use bitvec::prelude::{BitSlice, Lsb0};
 use rdkit::ROMol;
@@ -16,7 +16,7 @@ pub fn identity_search(
     query_descriptors: &HashMap<String, f64>,
     use_chirality: bool,
     extra_query: &str,
-) -> eyre::Result<Option<DocAddress>> {
+) -> eyre::Result<HashSet<DocAddress>> {
     let schema = searcher.schema();
 
     let query = build_identity_query(query_descriptors, extra_query, scaffold_matches);
@@ -26,6 +26,8 @@ pub fn identity_search(
 
     let smiles_field = schema.get_field("smiles")?;
     let fingerprint_field = schema.get_field("fingerprint")?;
+
+    let mut filtered_results: HashSet<DocAddress> = HashSet::new();
 
     for docaddr in initial_results {
         let doc = searcher.doc(docaddr)?;
@@ -51,12 +53,12 @@ pub fn identity_search(
             let mol_exact_match =
                 exact_match(&ROMol::from_smiles(smiles)?, query_mol, use_chirality);
             if mol_exact_match {
-                return Ok(Some(docaddr));
+                filtered_results.insert(docaddr);
             }
         }
     }
 
-    Ok(None)
+    Ok(filtered_results)
 }
 
 pub fn build_identity_query(

--- a/src/search/identity_search.rs
+++ b/src/search/identity_search.rs
@@ -14,6 +14,7 @@ pub fn identity_search(
     scaffold_matches: &Option<Vec<u64>>,
     query_fingerprint: &BitSlice<u8, Lsb0>,
     query_descriptors: &HashMap<String, f64>,
+    use_chirality: bool,
     extra_query: &str,
 ) -> eyre::Result<Option<DocAddress>> {
     let schema = searcher.schema();
@@ -47,7 +48,8 @@ pub fn identity_search(
         let fp_match = query_fingerprint == fingerprint_bits;
 
         if fp_match {
-            let mol_exact_match = exact_match(&ROMol::from_smiles(smiles)?, query_mol);
+            let mol_exact_match =
+                exact_match(&ROMol::from_smiles(smiles)?, query_mol, use_chirality);
             if mol_exact_match {
                 return Ok(Some(docaddr));
             }

--- a/src/search/structure_matching.rs
+++ b/src/search/structure_matching.rs
@@ -1,8 +1,9 @@
 use bitvec::prelude::BitSlice;
 use rdkit::*;
 
-pub fn exact_match(romol1: &ROMol, romol2: &ROMol) -> bool {
-    let params = SubstructMatchParameters::default();
+pub fn exact_match(romol1: &ROMol, romol2: &ROMol, use_chirality: bool) -> bool {
+    let mut params = SubstructMatchParameters::default();
+    params.set_use_chirality(use_chirality);
     let match1 = substruct_match(romol1, romol2, &params);
     let match2 = substruct_match(romol2, romol1, &params);
     !(match1.is_empty() || match2.is_empty())

--- a/src/search/structure_search.rs
+++ b/src/search/structure_search.rs
@@ -18,6 +18,7 @@ pub fn structure_search(
     method: &str,
     use_scaffolds: bool,
     result_limit: usize,
+    use_chirality: bool,
     extra_query: &str,
 ) -> eyre::Result<HashSet<DocAddress>> {
     let schema = searcher.schema();
@@ -75,7 +76,8 @@ pub fn structure_search(
         };
 
         if fp_match {
-            let params = SubstructMatchParameters::default();
+            let mut params = SubstructMatchParameters::default();
+            params.set_use_chirality(use_chirality);
             let mol_substruct_match = if method == "substructure" {
                 substruct_match(&ROMol::from_smiles(smiles)?, query_mol, &params)
             } else {

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -182,6 +182,7 @@ async fn test_index_and_search_endpoints() {
             Query(smi3.to_string()),
             Query(None),
             Query(None),
+            Query(None),
         )
         .await;
 
@@ -199,6 +200,7 @@ async fn test_index_and_search_endpoints() {
             Query(None),
             Query(None),
             Query(None),
+            Query(None),
         )
         .await;
 
@@ -211,6 +213,7 @@ async fn test_index_and_search_endpoints() {
         .v1_index_search_superstructure(
             Path(index_name.to_string()),
             Query("C1=CC=CC=C1CCC2=CC=CC=C2".to_string()),
+            Query(None),
             Query(None),
             Query(None),
             Query(None),

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -90,7 +90,7 @@ fn test_identity_search() {
         &extra_query,
     )
     .unwrap();
-    assert!(result.is_some());
+    assert_eq!(result.len(), 1);
 }
 
 #[test]

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -86,6 +86,7 @@ fn test_identity_search() {
         &None,
         query_fingerprint.0.as_bitslice(),
         &query_descriptors,
+        true,
         &extra_query,
     )
     .unwrap();
@@ -149,6 +150,7 @@ fn test_substructure_search() {
         "substructure",
         true,
         10,
+        true,
         &extra_query,
     )
     .unwrap();
@@ -213,6 +215,7 @@ fn test_superstructure_search() {
         "superstructure-search",
         true,
         10,
+        true,
         &extra_query,
     )
     .unwrap();

--- a/tests/structure_matching_tests.rs
+++ b/tests/structure_matching_tests.rs
@@ -9,8 +9,8 @@ fn test_exact_match() {
     let romol1 = ROMol::from_smiles(smiles1).unwrap();
     let romol2 = ROMol::from_smiles(smiles2).unwrap();
 
-    assert!(exact_match(&romol1, &romol1.clone()));
-    assert!(!exact_match(&romol1, &romol2));
+    assert!(exact_match(&romol1, &romol1.clone(), true));
+    assert!(!exact_match(&romol1, &romol2, true));
 }
 
 #[test]

--- a/tests/structure_matching_tests.rs
+++ b/tests/structure_matching_tests.rs
@@ -3,13 +3,14 @@ use rdkit::*;
 
 #[test]
 fn test_exact_match() {
-    let smiles1 = "CCC";
-    let smiles2 = "CCCC";
+    let smiles1 = "OC[C@H]1OC=C[C@@H](O)[C@@H]1O";
+    let smiles2 = "OCC1([H])OC=CC([H])(O)C1([H])O";
 
     let romol1 = ROMol::from_smiles(smiles1).unwrap();
     let romol2 = ROMol::from_smiles(smiles2).unwrap();
 
     assert!(exact_match(&romol1, &romol1.clone(), true));
+    assert!(exact_match(&romol1, &romol2, false));
     assert!(!exact_match(&romol1, &romol2, true));
 }
 


### PR DESCRIPTION
Resolves [#102](https://github.com/rdkit-rs/cheminee/issues/102) by adding the option to implement chiral substruct matches for the structure endpoints (i.e. identity, substructure, superstructure). The default is to ignore chirality.