### PR TITLE
Speed up scaffold assignment

### DIFF
--- a/benches/scaffold_benches.rs
+++ b/benches/scaffold_benches.rs
@@ -1,0 +1,15 @@
+#![feature(test)]
+
+extern crate test;
+use cheminee::search::compound_processing::process_cpd;
+use cheminee::search::scaffold_search::{scaffold_search, PARSED_SCAFFOLDS};
+use test::Bencher;
+
+#[bench]
+fn bench_scaffold_search(b: &mut Bencher) {
+    let smiles =
+        "C[S+](CC[C@@H](C(=O)[O-])[NH3+])C[C@@H]1[C@H]([C@H]([C@@H](O1)N2C=NC3=C(N=CN=C32)N)O)O";
+    let (mol, fp, _descriptors) = process_cpd(smiles, false).unwrap();
+
+    b.iter(|| scaffold_search(&fp.0, &mol, &PARSED_SCAFFOLDS));
+}

--- a/src/command_line/indexing/bulk_delete.rs
+++ b/src/command_line/indexing/bulk_delete.rs
@@ -65,10 +65,10 @@ pub fn create_delete_query(
     smiles: &str,
     query_parser: &QueryParser,
 ) -> eyre::Result<Box<dyn Query>> {
-    let (canon_taut, _fingerprint, descriptors) = process_cpd(smiles, false)?;
+    let (canon_taut, fingerprint, descriptors) = process_cpd(smiles, false)?;
 
     let canon_smiles = canon_taut.as_smiles();
-    let matching_scaffolds = scaffold_search(&canon_taut, &PARSED_SCAFFOLDS);
+    let matching_scaffolds = scaffold_search(&fingerprint.0, &canon_taut, &PARSED_SCAFFOLDS);
     let matching_scaffolds = match matching_scaffolds {
         Ok(matching_scaffolds) => Some(matching_scaffolds),
         Err(_) => None,

--- a/src/command_line/indexing/bulk_index.rs
+++ b/src/command_line/indexing/bulk_index.rs
@@ -119,10 +119,10 @@ fn create_tantivy_doc(
 
     let mut doc = doc!(
         smiles_field => canon_taut.as_smiles(),
-        fingerprint_field => fingerprint.0.into_vec()
+        fingerprint_field => fingerprint.0.clone().into_vec()
     );
 
-    let scaffold_matches = scaffold_search(&canon_taut, &PARSED_SCAFFOLDS)?;
+    let scaffold_matches = scaffold_search(&fingerprint.0, &canon_taut, &PARSED_SCAFFOLDS)?;
 
     let scaffold_json = match scaffold_matches.is_empty() {
         true => serde_json::json!({"scaffolds": vec![-1]}),

--- a/src/command_line/indexing/bulk_index.rs
+++ b/src/command_line/indexing/bulk_index.rs
@@ -119,7 +119,7 @@ fn create_tantivy_doc(
 
     let mut doc = doc!(
         smiles_field => canon_taut.as_smiles(),
-        fingerprint_field => fingerprint.0.clone().into_vec()
+        fingerprint_field => fingerprint.0.as_raw_slice()
     );
 
     let scaffold_matches = scaffold_search(&fingerprint.0, &canon_taut, &PARSED_SCAFFOLDS)?;

--- a/src/command_line/indexing/index_sdf.rs
+++ b/src/command_line/indexing/index_sdf.rs
@@ -204,7 +204,7 @@ fn create_tantivy_doc(
 
     let mut doc = doc!(
         smiles_field => canon_taut.as_smiles(),
-        fingerprint_field => fp.0.into_vec()
+        fingerprint_field => fp.0.clone().into_vec()
     );
 
     for field in KNOWN_DESCRIPTORS {
@@ -221,7 +221,7 @@ fn create_tantivy_doc(
         }
     }
 
-    let scaffold_matches = scaffold_search(&canon_taut, &PARSED_SCAFFOLDS)?;
+    let scaffold_matches = scaffold_search(&fp.0, &canon_taut, &PARSED_SCAFFOLDS)?;
 
     let scaffold_json = match scaffold_matches.is_empty() {
         true => serde_json::json!({"scaffolds": vec![-1]}),

--- a/src/command_line/indexing/index_sdf.rs
+++ b/src/command_line/indexing/index_sdf.rs
@@ -204,7 +204,7 @@ fn create_tantivy_doc(
 
     let mut doc = doc!(
         smiles_field => canon_taut.as_smiles(),
-        fingerprint_field => fp.0.clone().into_vec()
+        fingerprint_field => fp.0.as_raw_slice()
     );
 
     for field in KNOWN_DESCRIPTORS {

--- a/src/command_line/search/identity_search.rs
+++ b/src/command_line/search/identity_search.rs
@@ -86,7 +86,11 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
     let (query_canon_taut, fingerprint, descriptors) = prepare_query_structure(query_smiles)?;
 
     let matching_scaffolds = if use_scaffolds {
-        Some(scaffold_search(&query_canon_taut, &PARSED_SCAFFOLDS)?)
+        Some(scaffold_search(
+            &fingerprint.0,
+            &query_canon_taut,
+            &PARSED_SCAFFOLDS,
+        )?)
     } else {
         None
     };

--- a/src/rest_api/api/indexing/bulk_delete.rs
+++ b/src/rest_api/api/indexing/bulk_delete.rs
@@ -78,10 +78,10 @@ fn bulk_request_doc_to_query(
     bulk_request_doc: &BulkRequestDoc,
     query_parser: &QueryParser,
 ) -> eyre::Result<Box<dyn Query>> {
-    let (canon_taut, _fingerprint, descriptors) = process_cpd(&bulk_request_doc.smiles, false)?;
+    let (canon_taut, fingerprint, descriptors) = process_cpd(&bulk_request_doc.smiles, false)?;
 
     let canon_smiles = canon_taut.as_smiles();
-    let matching_scaffolds = scaffold_search(&canon_taut, &PARSED_SCAFFOLDS);
+    let matching_scaffolds = scaffold_search(&fingerprint.0, &canon_taut, &PARSED_SCAFFOLDS);
     let matching_scaffolds = match matching_scaffolds {
         Ok(matching_scaffolds) => Some(matching_scaffolds),
         Err(_) => None,

--- a/src/rest_api/api/indexing/bulk_index.rs
+++ b/src/rest_api/api/indexing/bulk_index.rs
@@ -131,9 +131,11 @@ fn bulk_request_doc_to_tantivy_doc(
         return Err(eyre::eyre!("not an object"));
     };
 
+    // let fp = fingerprint.0.as_raw_slice();
+
     let mut doc = tantivy::doc!(
         smiles_field => tautomer.as_smiles(),
-        fingerprint_field => fingerprint.0.clone().into_vec()
+        fingerprint_field => fingerprint.0.as_raw_slice()
     );
 
     let scaffolds = &PARSED_SCAFFOLDS;

--- a/src/rest_api/api/indexing/bulk_index.rs
+++ b/src/rest_api/api/indexing/bulk_index.rs
@@ -133,11 +133,11 @@ fn bulk_request_doc_to_tantivy_doc(
 
     let mut doc = tantivy::doc!(
         smiles_field => tautomer.as_smiles(),
-        fingerprint_field => fingerprint.0.into_vec()
+        fingerprint_field => fingerprint.0.clone().into_vec()
     );
 
     let scaffolds = &PARSED_SCAFFOLDS;
-    let scaffold_matches = scaffold_search(&tautomer, scaffolds)?;
+    let scaffold_matches = scaffold_search(&fingerprint.0, &tautomer, scaffolds)?;
 
     let scaffold_json = match scaffold_matches.is_empty() {
         true => serde_json::json!({"scaffolds": vec![-1]}),

--- a/src/rest_api/api/search/identity_search.rs
+++ b/src/rest_api/api/search/identity_search.rs
@@ -49,7 +49,7 @@ pub fn v1_index_search_identity(
     let (query_canon_taut, fingerprint, descriptors) = query_attributes;
 
     let matching_scaffolds = if use_scaffolds {
-        scaffold_search(&query_canon_taut, &PARSED_SCAFFOLDS).ok()
+        scaffold_search(&fingerprint.0, &query_canon_taut, &PARSED_SCAFFOLDS).ok()
     } else {
         None
     };

--- a/src/search/scaffold_search.rs
+++ b/src/search/scaffold_search.rs
@@ -8,7 +8,7 @@ use std::sync::Mutex;
 const SCAFFOLDS: &str = include_str!("../../assets/standardized_scaffolds_20240405.json");
 
 pub struct Scaffold {
-    pub fp: Arc<Mutex<BitVec<u8>>>,
+    pub fp: BitVec<u8>,
     pub mol: Arc<Mutex<ROMol>>,
     pub idx: u64,
 }
@@ -25,7 +25,7 @@ lazy_static::lazy_static! {
         let romol = ROMol::from_smiles(smiles).expect("failed to create ROMol from static smiles");
 
         Scaffold {
-            fp: Arc::new(Mutex::new(romol.fingerprint().0)),
+            fp: romol.fingerprint().0,
             mol: Arc::new(Mutex::new(romol)),
             idx: v.get("scaffold_id")
                 .expect("failed to get scaffold_id from static data")
@@ -46,7 +46,7 @@ pub fn scaffold_search(
 
     for scaffold in scaffolds {
         let fp_substruct_match =
-            substructure_match_fp(scaffold.fp.lock().unwrap().as_bitslice(), query_fingerprint);
+            substructure_match_fp(scaffold.fp.as_bitslice(), query_fingerprint);
 
         if fp_substruct_match {
             let mol_substruct_match =

--- a/src/search/scaffold_search.rs
+++ b/src/search/scaffold_search.rs
@@ -1,3 +1,5 @@
+use crate::search::structure_matching::substructure_match_fp;
+use bitvec::prelude::{BitSlice, BitVec};
 use rdkit::{substruct_match, ROMol, SubstructMatchParameters};
 use std::iter::Iterator;
 use std::sync::Arc;
@@ -5,8 +7,14 @@ use std::sync::Mutex;
 
 const SCAFFOLDS: &str = include_str!("../../assets/standardized_scaffolds_20240405.json");
 
+pub struct Scaffold {
+    pub fp: Arc<Mutex<BitVec<u8>>>,
+    pub mol: Arc<Mutex<ROMol>>,
+    pub idx: u64,
+}
+
 lazy_static::lazy_static! {
-    pub static ref PARSED_SCAFFOLDS: Vec<(Arc<Mutex<ROMol>>, u64)> = SCAFFOLDS
+    pub static ref PARSED_SCAFFOLDS: Vec<Scaffold> = SCAFFOLDS
     .lines()
     .map(|l| serde_json::from_str::<serde_json::Value>(l).unwrap())
     .map(|v| {
@@ -16,27 +24,36 @@ lazy_static::lazy_static! {
                 .unwrap();
         let romol = ROMol::from_smiles(smiles).expect("failed to create ROMol from static smiles");
 
-        (
-            Arc::new(Mutex::new(romol)),
-            v.get("scaffold_id")
+        Scaffold {
+            fp: Arc::new(Mutex::new(romol.fingerprint().0)),
+            mol: Arc::new(Mutex::new(romol)),
+            idx: v.get("scaffold_id")
                 .expect("failed to get scaffold_id from static data")
                 .as_u64()
                 .unwrap(),
-        )
+        }
     })
     .collect();
 }
 
 pub fn scaffold_search(
+    query_fingerprint: &BitSlice<u8>,
     query_mol: &ROMol,
-    scaffolds: &Vec<(Arc<Mutex<ROMol>>, u64)>,
+    scaffolds: &Vec<Scaffold>,
 ) -> eyre::Result<Vec<u64>> {
     let mut matching_scaffolds: Vec<u64> = Vec::with_capacity(scaffolds.len());
     for scaffold in scaffolds {
         let params = SubstructMatchParameters::default();
-        let mol_substruct_match = substruct_match(query_mol, &scaffold.0.lock().unwrap(), &params);
-        if !mol_substruct_match.is_empty() {
-            matching_scaffolds.push(scaffold.1);
+
+        let fp_substruct_match =
+            substructure_match_fp(scaffold.fp.lock().unwrap().as_bitslice(), query_fingerprint);
+
+        if fp_substruct_match {
+            let mol_substruct_match =
+                substruct_match(query_mol, &scaffold.mol.lock().unwrap(), &params);
+            if !mol_substruct_match.is_empty() {
+                matching_scaffolds.push(scaffold.idx);
+            }
         }
     }
 

--- a/src/search/scaffold_search.rs
+++ b/src/search/scaffold_search.rs
@@ -42,9 +42,9 @@ pub fn scaffold_search(
     scaffolds: &Vec<Scaffold>,
 ) -> eyre::Result<Vec<u64>> {
     let mut matching_scaffolds: Vec<u64> = Vec::with_capacity(scaffolds.len());
-    for scaffold in scaffolds {
-        let params = SubstructMatchParameters::default();
+    let params = SubstructMatchParameters::default();
 
+    for scaffold in scaffolds {
         let fp_substruct_match =
             substructure_match_fp(scaffold.fp.lock().unwrap().as_bitslice(), query_fingerprint);
 

--- a/src/search/structure_search.rs
+++ b/src/search/structure_search.rs
@@ -28,7 +28,11 @@ pub fn structure_search(
     let query_fingerprint = query_fingerprint.0.as_bitslice();
 
     let scaffold_matches = if use_scaffolds {
-        Some(scaffold_search(query_mol, &PARSED_SCAFFOLDS)?)
+        Some(scaffold_search(
+            query_fingerprint,
+            query_mol,
+            &PARSED_SCAFFOLDS,
+        )?)
     } else {
         None
     };

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -40,7 +40,7 @@ fn test_create_delete_query() {
 
     let mut doc = doc!(
         smiles_field => canon_taut.as_smiles(),
-        fingerprint_field => fingerprint.0.clone().into_vec()
+        fingerprint_field => fingerprint.0.as_raw_slice()
     );
 
     for (descriptor, val) in &descriptors {

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -50,7 +50,7 @@ fn test_identity_search() {
 
     let mut doc = doc!(
         smiles_field => test_smiles,
-        fingerprint_field => query_fingerprint.0.clone().into_vec()
+        fingerprint_field => query_fingerprint.0.as_raw_slice()
     );
 
     for (descriptor, val) in &query_descriptors {
@@ -114,7 +114,7 @@ fn test_substructure_search() {
 
     let mut doc = doc!(
         smiles_field => index_mol.as_smiles(),
-        fingerprint_field => index_fingerprint.0.clone().into_vec(),
+        fingerprint_field => index_fingerprint.0.as_raw_slice(),
         extra_data_field => json![{ "scaffolds": index_scaffolds }],
     );
 
@@ -180,7 +180,7 @@ fn test_superstructure_search() {
 
     let mut doc = doc!(
         smiles_field => index_mol.as_smiles(),
-        fingerprint_field => index_fingerprint.0.clone().into_vec(),
+        fingerprint_field => index_fingerprint.0.as_raw_slice(),
         extra_data_field => json![{ "scaffolds": index_scaffolds }],
     );
 

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -98,7 +98,8 @@ fn test_substructure_search() {
     let index_smiles = "C1=CC=CC=C1CC2=CC=CC=C2";
     let (index_mol, index_fingerprint, index_descriptors) =
         process_cpd(index_smiles, false).unwrap();
-    let index_scaffolds = scaffold_search(&index_mol, &PARSED_SCAFFOLDS).unwrap();
+    let index_scaffolds =
+        scaffold_search(&index_fingerprint.0, &index_mol, &PARSED_SCAFFOLDS).unwrap();
 
     let query_smiles = "C1=CC=CC=C1";
     let query_mol = standardize_smiles(query_smiles, false).unwrap();
@@ -163,7 +164,8 @@ fn test_superstructure_search() {
     let index_smiles = "C1=CC=CC=C1";
     let (index_mol, index_fingerprint, index_descriptors) =
         process_cpd(index_smiles, false).unwrap();
-    let index_scaffolds = scaffold_search(&index_mol, &PARSED_SCAFFOLDS).unwrap();
+    let index_scaffolds =
+        scaffold_search(&index_fingerprint.0, &index_mol, &PARSED_SCAFFOLDS).unwrap();
 
     let query_smiles = "C1=CC=CC=C1CC2=CC=CC=C2";
     let query_mol = standardize_smiles(query_smiles, false).unwrap();


### PR DESCRIPTION
Resolves [#104](https://github.com/rdkit-rs/cheminee/issues/104) by introducing a fingerprint screen to the scaffold search method. This seems to speed up scaffold assignment by 2.7-fold (at least for the benched example). This should significantly speed up indexing and structure searches since these both incorporate scaffold assignment.

Before fingerprint screen:
<img width="706" alt="Screenshot 2024-09-20 at 8 47 36 AM" src="https://github.com/user-attachments/assets/1e375330-6834-4a3c-9511-e74614b27c30">


After incorporating fingerprint screen:
<img width="714" alt="Screenshot 2024-09-20 at 9 02 31 AM" src="https://github.com/user-attachments/assets/034f5778-0062-4967-b478-ce7da26455ec">
