### PR TITLE
More search improvements

### DIFF
--- a/src/search/basic_search.rs
+++ b/src/search/basic_search.rs
@@ -1,5 +1,5 @@
+use rayon::prelude::*;
 use std::collections::HashSet;
-
 use tantivy::{collector::TopDocs, query::QueryParser, DocAddress, Searcher};
 
 #[allow(clippy::ptr_arg)]
@@ -13,7 +13,7 @@ pub fn basic_search(
     let query = query_parser.parse_query(query)?;
     let results = searcher.search(&query, &TopDocs::with_limit(limit))?;
     let final_results = results
-        .into_iter()
+        .into_par_iter()
         .map(|result| result.1)
         .collect::<HashSet<DocAddress>>();
     Ok(final_results)

--- a/src/search/identity_search.rs
+++ b/src/search/identity_search.rs
@@ -1,12 +1,13 @@
-use std::collections::{HashMap, HashSet};
-
-use bitvec::prelude::{BitSlice, Lsb0};
-use rdkit::ROMol;
-use regex::Regex;
-use tantivy::Searcher;
-
 use crate::search::structure_matching::exact_match;
 use crate::search::{basic_search::basic_search, STRUCTURE_MATCH_DESCRIPTORS};
+use bitvec::prelude::{BitSlice, Lsb0};
+use rayon::prelude::*;
+use rdkit::ROMol;
+use regex::Regex;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+use tantivy::schema::Field;
+use tantivy::{DocAddress, Searcher};
 
 pub fn identity_search(
     searcher: &Searcher,
@@ -28,45 +29,76 @@ pub fn identity_search(
     let fingerprint_field = schema.get_field("fingerprint")?;
     let extra_data_field = schema.get_field("extra_data")?;
 
-    let mut filtered_results: HashSet<(String, String)> = HashSet::new();
+    let query_mol_mutex = Arc::new(Mutex::new(query_mol.clone()));
 
-    for docaddr in initial_results {
-        let doc = searcher.doc(docaddr)?;
+    let filtered_results = initial_results
+        .into_par_iter()
+        .filter_map(|result| {
+            let confirmed_match = identity_match(
+                result,
+                smiles_field,
+                fingerprint_field,
+                extra_data_field,
+                &searcher,
+                &query_mol_mutex.lock().unwrap(),
+                query_fingerprint,
+                use_chirality,
+            );
 
-        let smiles = doc
-            .get_first(smiles_field)
-            .ok_or(eyre::eyre!("Tantivy smiles retrieval failed"))?
-            .as_text()
-            .ok_or(eyre::eyre!("Failed to stringify smiles"))?;
-
-        let fingerprint = doc
-            .get_first(fingerprint_field)
-            .ok_or(eyre::eyre!("Tantivy fingerprint retrieval failed"))?
-            .as_bytes()
-            .ok_or(eyre::eyre!("Failed to read fingerprint as bytes"))?;
-
-        let fingerprint_bits = BitSlice::<u8, Lsb0>::from_slice(fingerprint);
-        let fp_match = query_fingerprint == fingerprint_bits;
-
-        if fp_match {
-            let mol_exact_match =
-                exact_match(&ROMol::from_smiles(smiles)?, query_mol, use_chirality);
-            if mol_exact_match {
-                let extra_data = match doc.get_first(extra_data_field) {
-                    Some(extra_data) => serde_json::to_string(
-                        extra_data
-                            .as_json()
-                            .ok_or(eyre::eyre!("Failed to jsonify extra data"))?,
-                    )?,
-                    None => "".to_string(),
-                };
-
-                filtered_results.insert((smiles.to_string(), extra_data));
+            if let Ok(confirmed_match) = confirmed_match {
+                confirmed_match
+            } else {
+                None
             }
+        })
+        .collect::<HashSet<(String, String)>>();
+
+    Ok(filtered_results)
+}
+
+pub fn identity_match(
+    docaddr: DocAddress,
+    smiles_field: Field,
+    fingerprint_field: Field,
+    extra_data_field: Field,
+    searcher: &Searcher,
+    query_mol: &ROMol,
+    query_fingerprint: &BitSlice<u8>,
+    use_chirality: bool,
+) -> eyre::Result<Option<(String, String)>> {
+    let doc = searcher.doc(docaddr)?;
+
+    let smiles = doc
+        .get_first(smiles_field)
+        .ok_or(eyre::eyre!("Tantivy smiles retrieval failed"))?
+        .as_text()
+        .ok_or(eyre::eyre!("Failed to stringify smiles"))?;
+
+    let fingerprint = doc
+        .get_first(fingerprint_field)
+        .ok_or(eyre::eyre!("Tantivy fingerprint retrieval failed"))?
+        .as_bytes()
+        .ok_or(eyre::eyre!("Failed to read fingerprint as bytes"))?;
+
+    let fingerprint_bits = BitSlice::<u8, Lsb0>::from_slice(fingerprint);
+    let fp_match = query_fingerprint == fingerprint_bits;
+
+    if fp_match {
+        let mol_exact_match = exact_match(&ROMol::from_smiles(smiles)?, query_mol, use_chirality);
+        if mol_exact_match {
+            let extra_data = match doc.get_first(extra_data_field) {
+                Some(extra_data) => serde_json::to_string(
+                    extra_data
+                        .as_json()
+                        .ok_or(eyre::eyre!("Failed to jsonify extra data"))?,
+                )?,
+                None => "".to_string(),
+            };
+            return Ok(Some((smiles.to_string(), extra_data)));
         }
     }
 
-    Ok(filtered_results)
+    Ok(None)
 }
 
 pub fn build_identity_query(

--- a/src/search/structure_search.rs
+++ b/src/search/structure_search.rs
@@ -1,16 +1,18 @@
-use std::collections::{HashMap, HashSet};
-
-use bitvec::prelude::{BitSlice, Lsb0};
-use rdkit::{substruct_match, ROMol, SubstructMatchParameters};
-use regex::Regex;
-use tantivy::Searcher;
-
 use crate::search::compound_processing::get_cpd_properties;
 use crate::search::scaffold_search::{scaffold_search, PARSED_SCAFFOLDS};
 use crate::search::{
     basic_search::basic_search, structure_matching::substructure_match_fp,
     STRUCTURE_MATCH_DESCRIPTORS,
 };
+use bitvec::macros::internal::funty::Fundamental;
+use bitvec::prelude::{BitSlice, Lsb0};
+use rayon::prelude::*;
+use rdkit::{substruct_match, ROMol, SubstructMatchParameters};
+use regex::Regex;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+use tantivy::schema::Field;
+use tantivy::{DocAddress, Searcher};
 
 pub fn structure_search(
     searcher: &Searcher,
@@ -40,67 +42,107 @@ pub fn structure_search(
     };
 
     let tantivy_limit = 100_000;
-    let filtered_results1 = basic_search(searcher, &query, tantivy_limit)?;
+    let initial_results = basic_search(searcher, &query, tantivy_limit)?;
 
     let smiles_field = schema.get_field("smiles")?;
     let fingerprint_field = schema.get_field("fingerprint")?;
     let extra_data_field = schema.get_field("extra_data")?;
 
-    let mut filtered_results2: HashSet<(String, String)> = HashSet::new();
+    let result_count: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+    let query_mol_mutex = Arc::new(Mutex::new(query_mol.clone()));
 
-    for docaddr in filtered_results1 {
-        if filtered_results2.len() >= result_limit {
-            break;
-        }
+    let filtered_results = initial_results
+        .into_par_iter()
+        .filter_map(|result| {
+            let mut num = result_count.lock().unwrap();
 
-        let doc = searcher.doc(docaddr)?;
+            if num.as_usize() > result_limit {
+                None
+            } else {
+                let struct_match = structure_match(
+                    result,
+                    smiles_field,
+                    fingerprint_field,
+                    extra_data_field,
+                    &searcher,
+                    &query_mol_mutex.lock().unwrap(),
+                    query_fingerprint,
+                    method,
+                    use_chirality,
+                );
 
-        let smiles = doc
-            .get_first(smiles_field)
-            .ok_or(eyre::eyre!("Tantivy smiles retrieval failed"))?
-            .as_text()
-            .ok_or(eyre::eyre!("Failed to stringify smiles"))?;
+                if let Ok(struct_match) = struct_match {
+                    *num += 1;
+                    struct_match
+                } else {
+                    None
+                }
+            }
+        })
+        .collect::<HashSet<(String, String)>>();
 
-        // TO-DO: find a zero-copy bitvec container
-        let fingerprint = doc
-            .get_first(fingerprint_field)
-            .ok_or(eyre::eyre!("Tantivy fingerprint retrieval failed"))?
-            .as_bytes()
-            .ok_or(eyre::eyre!("Failed to read fingerprint as bytes"))?;
+    Ok(filtered_results)
+}
 
-        let fingerprint_bits = BitSlice::<u8, Lsb0>::from_slice(fingerprint);
+pub fn structure_match(
+    docaddr: DocAddress,
+    smiles_field: Field,
+    fingerprint_field: Field,
+    extra_data_field: Field,
+    searcher: &Searcher,
+    query_mol: &ROMol,
+    query_fingerprint: &BitSlice<u8>,
+    method: &str,
+    use_chirality: bool,
+) -> eyre::Result<Option<(String, String)>> {
+    let doc = searcher.doc(docaddr)?;
 
-        let fp_match = if method == "substructure" {
-            substructure_match_fp(query_fingerprint, fingerprint_bits)
+    let smiles = doc
+        .get_first(smiles_field)
+        .ok_or(eyre::eyre!("Tantivy smiles retrieval failed"))?
+        .as_text()
+        .ok_or(eyre::eyre!("Failed to stringify smiles"))?;
+
+    // TO-DO: find a zero-copy bitvec container
+    let fingerprint = doc
+        .get_first(fingerprint_field)
+        .ok_or(eyre::eyre!("Tantivy fingerprint retrieval failed"))?
+        .as_bytes()
+        .ok_or(eyre::eyre!("Failed to read fingerprint as bytes"))?;
+
+    let fingerprint_bits = BitSlice::<u8, Lsb0>::from_slice(fingerprint);
+
+    let fp_match = if method == "substructure" {
+        substructure_match_fp(query_fingerprint, fingerprint_bits)
+    } else {
+        substructure_match_fp(fingerprint_bits, query_fingerprint)
+    };
+
+    if fp_match {
+        let mut params = SubstructMatchParameters::default();
+        params.set_use_chirality(use_chirality);
+
+        let mol_substruct_match = if method == "substructure" {
+            substruct_match(&ROMol::from_smiles(smiles)?, query_mol, &params)
         } else {
-            substructure_match_fp(fingerprint_bits, query_fingerprint)
+            substruct_match(query_mol, &ROMol::from_smiles(smiles)?, &params)
         };
 
-        if fp_match {
-            let mut params = SubstructMatchParameters::default();
-            params.set_use_chirality(use_chirality);
-            let mol_substruct_match = if method == "substructure" {
-                substruct_match(&ROMol::from_smiles(smiles)?, query_mol, &params)
-            } else {
-                substruct_match(query_mol, &ROMol::from_smiles(smiles)?, &params)
+        if !mol_substruct_match.is_empty() && query_mol.as_smiles() != smiles {
+            let extra_data = match doc.get_first(extra_data_field) {
+                Some(extra_data) => serde_json::to_string(
+                    extra_data
+                        .as_json()
+                        .ok_or(eyre::eyre!("Failed to jsonify extra data"))?,
+                )?,
+                None => "".to_string(),
             };
 
-            if !mol_substruct_match.is_empty() && query_mol.as_smiles() != smiles {
-                let extra_data = match doc.get_first(extra_data_field) {
-                    Some(extra_data) => serde_json::to_string(
-                        extra_data
-                            .as_json()
-                            .ok_or(eyre::eyre!("Failed to jsonify extra data"))?,
-                    )?,
-                    None => "".to_string(),
-                };
-
-                filtered_results2.insert((smiles.to_string(), extra_data));
-            }
+            return Ok(Some((smiles.to_string(), extra_data)));
         }
     }
 
-    Ok(filtered_results2)
+    Ok(None)
 }
 
 pub fn build_substructure_query(

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -48,9 +48,13 @@ fn test_identity_search() {
     let smiles_field = builder.add_text_field("smiles", STRING | STORED);
     let fingerprint_field = builder.add_bytes_field("fingerprint", FAST | STORED);
 
+    let json_options: JsonObjectOptions =
+        JsonObjectOptions::from(TEXT | STORED).set_expand_dots_enabled();
+    let _extra_data_field = builder.add_json_field("extra_data", json_options);
+
     let mut doc = doc!(
-        smiles_field => test_smiles,
-        fingerprint_field => query_fingerprint.0.clone().into_vec()
+        smiles_field => query_mol.as_smiles(),
+        fingerprint_field => query_fingerprint.0.clone().into_vec(),
     );
 
     for (descriptor, val) in &query_descriptors {


### PR DESCRIPTION
Resolves [#106 ](https://github.com/rdkit-rs/cheminee/issues/106) by adding more multithreading to the underlying structure search methods so that fingerprint screening and structure matches can be parallelized.

There is also some IO improvement: there were some places where we were opening the same docs multiple times to access the same data we were working with earlier. Now the docs are only opened once and the relevant data for the passing compounds are recorded as we go along.