### PR TITLE
Switch to ruby's faraday http library

### DIFF
--- a/.github/workflows/generate_ruby_gem.yaml
+++ b/.github/workflows/generate_ruby_gem.yaml
@@ -60,7 +60,7 @@ jobs:
           generator: ruby
           config-file: cheminee-ruby/openapi-generator-config.json
           openapi-file: openapi.json
-          command-args: "--additional-properties='gemVersion=${{  steps.ref_name.outputs.result }}' --output=cheminee-ruby"
+          command-args: "--additional-properties='gemVersion=${{  steps.ref_name.outputs.result }} --library=faraday' --output=cheminee-ruby"
 
       - run: echo "Gemfile.lock" >> cheminee-ruby/.gitignore
 
@@ -85,7 +85,7 @@ jobs:
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials
           printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-          
+
           bundle install
           rake build
           git status


### PR DESCRIPTION
Our users want faraday. Find other options here: https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/ruby.md