### PR TITLE
Ensure search results and result order are reproducible

### DIFF
--- a/src/command_line/search/cli_structure_search.rs
+++ b/src/command_line/search/cli_structure_search.rs
@@ -1,6 +1,6 @@
 use crate::command_line::prelude::*;
 use crate::search::structure_search::structure_search;
-use crate::search::{compound_processing::*, validate_structure, StructureSearchHit};
+use crate::search::{compound_processing::*, sort_results, validate_structure, StructureSearchHit};
 use rayon::iter::ParallelIterator;
 use rayon::prelude::IntoParallelIterator;
 use std::cmp::min;
@@ -107,8 +107,10 @@ pub fn cli_structure_search(method: &str, matches: &ArgMatches) -> eyre::Result<
         }
     }
 
-    let final_results = results
-        .into_par_iter()
+    let mut data_results = results.into_iter().collect::<Vec<_>>();
+
+    let final_results = sort_results(&mut data_results)
+        .into_iter()
         .map(|(smiles, extra_data)| StructureSearchHit {
             extra_data,
             smiles,

--- a/src/command_line/search/cli_structure_search.rs
+++ b/src/command_line/search/cli_structure_search.rs
@@ -79,7 +79,7 @@ pub fn cli_structure_search(method: &str, matches: &ArgMatches) -> eyre::Result<
         let tautomer_limit = min(tautomers.len(), tautomer_limit);
 
         if !tautomers.is_empty() {
-            let tautomer_results = &tautomers[..tautomer_limit]
+            let tautomer_results = tautomers[..tautomer_limit]
                 .into_par_iter()
                 .filter_map(|taut| {
                     structure_search(
@@ -97,7 +97,7 @@ pub fn cli_structure_search(method: &str, matches: &ArgMatches) -> eyre::Result<
 
             for results_set in tautomer_results {
                 if results.len() < result_limit {
-                    results.extend(results_set.clone());
+                    results.extend(results_set);
                 }
             }
 

--- a/src/command_line/search/identity_search.rs
+++ b/src/command_line/search/identity_search.rs
@@ -1,9 +1,8 @@
 use crate::command_line::prelude::*;
 use crate::search::scaffold_search::{scaffold_search, PARSED_SCAFFOLDS};
 use crate::search::{
-    identity_search::identity_search, prepare_query_structure, StructureSearchHit,
+    identity_search::identity_search, prepare_query_structure, sort_results, StructureSearchHit,
 };
-use rayon::prelude::*;
 
 pub const NAME: &str = "identity-search";
 
@@ -96,7 +95,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         None
     };
 
-    let results = identity_search(
+    let mut data_results = identity_search(
         &searcher,
         &query_canon_taut,
         &matching_scaffolds,
@@ -106,8 +105,8 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         &extra_query,
     )?;
 
-    let final_results = results
-        .into_par_iter()
+    let final_results = sort_results(&mut data_results)
+        .into_iter()
         .map(|(smiles, extra_data)| StructureSearchHit {
             extra_data,
             smiles,

--- a/src/rest_api/api/search/identity_search.rs
+++ b/src/rest_api/api/search/identity_search.rs
@@ -2,10 +2,9 @@ use crate::indexing::index_manager::IndexManager;
 use crate::rest_api::api::{GetStructureSearchResponse, StructureResponseError};
 use crate::search::scaffold_search::{scaffold_search, PARSED_SCAFFOLDS};
 use crate::search::{
-    identity_search::identity_search, prepare_query_structure, StructureSearchHit,
+    identity_search::identity_search, prepare_query_structure, sort_results, StructureSearchHit,
 };
 use poem_openapi::payload::Json;
-use rayon::prelude::*;
 
 pub fn v1_index_search_identity(
     index_manager: &IndexManager,
@@ -55,7 +54,7 @@ pub fn v1_index_search_identity(
         None
     };
 
-    let results = identity_search(
+    let data_results = identity_search(
         &searcher,
         &query_canon_taut,
         &matching_scaffolds,
@@ -65,9 +64,9 @@ pub fn v1_index_search_identity(
         extra_query,
     );
 
-    let final_results = match results {
-        Ok(results) => results
-            .into_par_iter()
+    let final_results = match data_results {
+        Ok(mut data_results) => sort_results(&mut data_results)
+            .into_iter()
             .map(|(smiles, extra_data)| StructureSearchHit {
                 extra_data,
                 smiles,

--- a/src/rest_api/api/search/structure_search.rs
+++ b/src/rest_api/api/search/structure_search.rs
@@ -91,7 +91,7 @@ pub fn v1_index_search_structure(
         let tautomer_limit = min(tautomers.len(), tautomer_limit);
 
         if !tautomers.is_empty() {
-            let tautomer_results = &tautomers[..tautomer_limit]
+            let tautomer_results = tautomers[..tautomer_limit]
                 .into_par_iter()
                 .filter_map(|taut| {
                     structure_search(
@@ -109,7 +109,7 @@ pub fn v1_index_search_structure(
 
             for results_set in tautomer_results {
                 if results.len() < result_limit {
-                    results.extend(results_set.clone());
+                    results.extend(results_set);
                 }
             }
 

--- a/src/rest_api/api/search/structure_search.rs
+++ b/src/rest_api/api/search/structure_search.rs
@@ -1,7 +1,9 @@
 use crate::rest_api::api::{GetStructureSearchResponse, StructureResponseError};
 use crate::search::compound_processing::standardize_smiles;
 use crate::search::structure_search::structure_search;
-use crate::search::{compound_processing::get_tautomers, validate_structure, StructureSearchHit};
+use crate::search::{
+    compound_processing::get_tautomers, sort_results, validate_structure, StructureSearchHit,
+};
 use poem_openapi::payload::Json;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
@@ -117,8 +119,10 @@ pub fn v1_index_search_structure(
         }
     }
 
-    let final_results = results
-        .into_par_iter()
+    let mut data_results = results.into_iter().collect::<Vec<_>>();
+
+    let final_results = sort_results(&mut data_results)
+        .into_iter()
         .map(|(smiles, extra_data)| StructureSearchHit {
             extra_data,
             smiles,

--- a/src/search/identity_search.rs
+++ b/src/search/identity_search.rs
@@ -39,7 +39,7 @@ pub fn identity_search(
                 smiles_field,
                 fingerprint_field,
                 extra_data_field,
-                &searcher,
+                searcher,
                 &query_mol_mutex.lock().unwrap(),
                 query_fingerprint,
                 use_chirality,

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use crate::search::compound_processing::process_cpd;
 use poem_openapi_derive::Object;
@@ -81,7 +81,7 @@ pub struct StructureSearchHit {
 
 pub fn aggregate_query_hits(
     searcher: Searcher,
-    results: HashSet<DocAddress>,
+    results: Vec<DocAddress>,
     query: &str,
 ) -> eyre::Result<Vec<QuerySearchHit>> {
     let schema = searcher.schema();

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -7,7 +7,7 @@ use rdkit::{
     detect_chemistry_problems, Fingerprint, MolSanitizeException, ROMol, SmilesParserParams,
 };
 use tantivy::schema::Field;
-use tantivy::{DocAddress, Searcher};
+use tantivy::{DocAddress, DocId, Searcher, SegmentOrdinal};
 
 pub mod basic_search;
 pub mod compound_processing;
@@ -88,18 +88,16 @@ pub fn aggregate_query_hits(
     let smiles_field = schema.get_field("smiles")?;
     let extra_data_field = schema.get_field("extra_data")?;
 
-    let final_results = results
+    let mut data_results = results
         .into_par_iter()
         .filter_map(|result| {
             let smiles_and_extra_data =
                 get_smiles_and_extra_data(result, &searcher, smiles_field, extra_data_field);
 
             match smiles_and_extra_data {
-                Ok((smiles, extra_data)) => Some(QuerySearchHit {
-                    extra_data,
-                    smiles,
-                    query: query.into(),
-                }),
+                Ok((smiles, extra_data)) => {
+                    Some((smiles, extra_data, result.segment_ord, result.doc_id))
+                }
                 Err(e) => {
                     log::error!("{:?}", e);
                     None
@@ -108,7 +106,16 @@ pub fn aggregate_query_hits(
         })
         .collect::<Vec<_>>();
 
-    Ok(final_results)
+    let sorted_results = sort_results(&mut data_results)
+        .into_iter()
+        .map(|(smiles, extra_data)| QuerySearchHit {
+            extra_data,
+            smiles,
+            query: query.into(),
+        })
+        .collect::<Vec<_>>();
+
+    Ok(sorted_results)
 }
 
 fn get_smiles_and_extra_data(
@@ -135,4 +142,23 @@ fn get_smiles_and_extra_data(
     };
 
     Ok((smiles.to_string(), extra_data.to_string()))
+}
+
+pub fn sort_results(
+    results: &mut [(String, String, SegmentOrdinal, DocId)],
+) -> Vec<(String, String)> {
+    results.sort_by(|a, b| {
+        let cmp = a.2.cmp(&b.2);
+
+        if cmp == std::cmp::Ordering::Equal {
+            a.3.partial_cmp(&b.3).unwrap_or(std::cmp::Ordering::Equal)
+        } else {
+            cmp
+        }
+    });
+
+    results
+        .iter_mut()
+        .map(|(data1, data2, _, _)| (data1.to_owned(), data2.to_owned()))
+        .collect::<Vec<_>>()
 }

--- a/src/search/structure_search.rs
+++ b/src/search/structure_search.rs
@@ -4,7 +4,6 @@ use crate::search::{
     basic_search::basic_search, structure_matching::substructure_match_fp,
     STRUCTURE_MATCH_DESCRIPTORS,
 };
-use bitvec::macros::internal::funty::Fundamental;
 use bitvec::prelude::{BitSlice, Lsb0};
 use rayon::prelude::*;
 use rdkit::{substruct_match, ROMol, SubstructMatchParameters};
@@ -52,42 +51,41 @@ pub fn structure_search(
     let fingerprint_field = schema.get_field("fingerprint")?;
     let extra_data_field = schema.get_field("extra_data")?;
 
-    let result_count: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
     let query_mol_mutex = Arc::new(Mutex::new(query_mol.clone()));
 
-    let filtered_results = initial_results
-        .into_par_iter()
-        .filter_map(|result| {
-            let mut num = result_count.lock().unwrap();
+    let mut result_count: usize = 0;
+    let mut filtered_results: HashSet<(String, String, SegmentOrdinal, DocId)> = HashSet::new();
 
-            if num.as_usize() > result_limit {
-                None
-            } else {
+    for chunk in initial_results.chunks(1000) {
+        if result_count > result_limit {
+            break;
+        }
+
+        let results_subset = chunk
+            .into_par_iter()
+            .filter_map(|result| {
                 let struct_match = structure_match(
-                    result,
+                    *result,
                     smiles_field,
                     fingerprint_field,
                     extra_data_field,
-                    &searcher,
+                    searcher,
                     &query_mol_mutex.lock().unwrap(),
                     query_fingerprint,
                     method,
                     use_chirality,
                 );
 
-                match struct_match {
-                    Ok(struct_match) => {
-                        *num += 1;
-                        struct_match
-                    }
-                    Err(e) => {
-                        log::error!("{:?}", e);
-                        None
-                    }
-                }
-            }
-        })
-        .collect::<HashSet<(String, String, SegmentOrdinal, DocId)>>();
+                struct_match.unwrap_or_else(|e| {
+                    log::error!("{:?}", e);
+                    None
+                })
+            })
+            .collect::<HashSet<(String, String, SegmentOrdinal, DocId)>>();
+
+        result_count += results_subset.len();
+        filtered_results.extend(results_subset);
+    }
 
     Ok(filtered_results)
 }


### PR DESCRIPTION
Resolves [#115](https://github.com/rdkit-rs/cheminee/issues/115) by ensuring that results are reproducible for each of the search endpoints.

At the moment, results are sorted in a couple instances:

- After an initial `basic-search` the doc addresses are sorted by `segment_ord` and `doc_id`. Note: every search endpoint performs a `basic-search` as the first search step.
- After the secondary structure-based search (i.e. implemented in the case of `identity-search`, `substructure-search`, and `superstructure-search`), the remaining results are sorted again since order was lost due to multithreading. Luckily, this sorting is less computationally intensive since we will have _much_ fewer structure matches compared to the `basic-search` matches.

**Note**
So why does the `basic-search` results need to be sorted if the secondary filter results get sorted later? This is necessary because Cheminee does not necessary look at all of the initial results from the `basic-search` step. If the desired result limit is reached, we want to exit without having to look at the remaining results (i.e. we aren't using scoring at the moment, so any end result is as good as another). This means we need to ensure that the `basic-search` results are sorted before we chunk the array and iterate over the chunks and apply multithreaded filtering of each chunk, one at a time. If we get to the next chunk but have accumulated enough results, we can exit.