### PR TITLE
Validate standardized molecules

### DIFF
--- a/src/search/compound_processing.rs
+++ b/src/search/compound_processing.rs
@@ -152,6 +152,10 @@ pub fn standardize_mol(romol: &ROMol) -> eyre::Result<ROMol> {
     let te = TautomerEnumerator::new();
     let canon_taut = te.canonicalize(&parent_rwmol.to_ro_mol())?;
     let neutralized_canon = neutralize_atoms(&canon_taut)?;
+
+    // Validate
+    let _ = ROMol::from_smiles(&neutralized_canon.as_smiles())
+        .map_err(|_| eyre::eyre!("Canonicalization failed validation"))?;
     Ok(neutralized_canon)
 }
 

--- a/tests/cpd_processing_tests.rs
+++ b/tests/cpd_processing_tests.rs
@@ -100,6 +100,17 @@ fn test_standardize_bad_smiles() {
 }
 
 #[test]
+fn test_bad_standardization() {
+    // The smiles below is technically a perfectly valid smiles
+    // but at the moment our standardization procedure can mess up isotopic hydrogens.
+    // This is a rare occurrence so it's maybe not worth fixing these cases specifically just yet.
+    // That said, we should at least force an error in these cases.
+    let smiles = "O=C(O[2H])C(F)(F)F";
+    let result = standardize_smiles(smiles, false);
+    assert!(result.is_err());
+}
+
+#[test]
 fn test_get_tautomers() {
     let smiles = "Oc1c(cccc3)c3nc2ccncc12";
     let romol = ROMol::from_smiles(smiles).unwrap();


### PR DESCRIPTION
Resolves [#117](https://github.com/rdkit-rs/cheminee/issues/117) by adding a final validation step in the `standardize_mol()` method. This will catch the rare generation of invalid molecules from the standardization procedure.