### PR TITLE
Rebuild tensorflow saved model bundle as needed to segmentation fault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "cheminee-similarity-model"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c09686b3068fe0035846021102f38a9e4e8b2144785fdb02f5469043950d7c29"
+checksum = "ac0fe7844109f5f03373536d0f9903501a2dedd8195cc897ec862b42bbd94a40"
 dependencies = [
  "eyre",
  "flate2",

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN cd /tmp && \
 
 ENV CARGO_MANIFEST_DIR=/usr/local/lib/
 
+ENV TF_CPP_MIN_LOG_LEVEL=3
+
 COPY target/release/build/ /usr/local/lib/target/release/build/
 RUN find /usr/local/lib/target/release/build/ -mindepth 1 -type d ! -path "/usr/local/lib/target/release/build/cheminee-similarity-model-*" -exec rm -rf {} +
 COPY target/release/cheminee /usr/local/bin/cheminee

--- a/src/search/similarity_search.rs
+++ b/src/search/similarity_search.rs
@@ -145,8 +145,7 @@ pub fn encode_fingerprint(bit_vec: &BitVec<u8>, only_best_cluster: bool) -> eyre
         .map(|b| if *b { 1 } else { 0 })
         .collect::<Vec<u8>>();
 
-    let ranked_clusters = build_encoder_model()?
-        .transform(&fp_vec)?;
+    let ranked_clusters = build_encoder_model()?.transform(&fp_vec)?;
 
     if only_best_cluster {
         Ok(vec![ranked_clusters[0]])


### PR DESCRIPTION
It seems that using `Arc<Mutex` did not solve the segmentation fault from [#126](https://github.com/rdkit-rs/cheminee/issues/126). This PR resolves the issue by re-building the similarity model each time it is needed for fingerprint encodings. This way, a model's `session` is used only once. 

This solution comes at a performance cost however since rebuilding the model takes about 20-30 milliseconds. This has the effect of making compound indexing 4x slower. This can be mitigated with more CPUs, but can also be improved significantly by batching the encoding steps for a batch of fingerprints (at the moment, fingerprints are getting encoded by the similarity model one at a time). Batching the encoding step will be the work of a subsequent PR.