### PR TITLE
Batch fingerprint encodings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,6 +328,8 @@ dependencies = [
 [[package]]
 name = "cheminee-similarity-model"
 version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b2b130dde03c7fa9f59a740ff323f1b7bf107f91fedf3424e51d08bda9610f5"
 dependencies = [
  "eyre",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,9 +327,7 @@ dependencies = [
 
 [[package]]
 name = "cheminee-similarity-model"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac0fe7844109f5f03373536d0f9903501a2dedd8195cc897ec862b42bbd94a40"
+version = "0.1.5"
 dependencies = [
  "eyre",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "cheminee-similarity-model"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2b130dde03c7fa9f59a740ff323f1b7bf107f91fedf3424e51d08bda9610f5"
+checksum = "47d7c7f4a739a785fbd3e77e8958e21d29ea64cc463a033f3608fa137fe6bb5c"
 dependencies = [
  "eyre",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://rdkit-rs.github.io"
 
 [dependencies]
 bitvec = "1"
-cheminee-similarity-model = { path = "../cheminee-similarity-model" }
+cheminee-similarity-model = "0.1.5"
 clap = "4"
 eyre = "0"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://rdkit-rs.github.io"
 
 [dependencies]
 bitvec = "1"
-cheminee-similarity-model = "0.1"
+cheminee-similarity-model = { path = "../cheminee-similarity-model" }
 clap = "4"
 eyre = "0"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://rdkit-rs.github.io"
 
 [dependencies]
 bitvec = "1"
-cheminee-similarity-model = "0.1.5"
+cheminee-similarity-model = "0.1.6"
 clap = "4"
 eyre = "0"
 lazy_static = "1.4"

--- a/src/command_line/indexing/bulk_index.rs
+++ b/src/command_line/indexing/bulk_index.rs
@@ -3,7 +3,6 @@ use crate::indexing::index_manager::IndexManager;
 use crate::search::compound_processing::process_cpd;
 use crate::search::scaffold_search::{scaffold_search, PARSED_SCAFFOLDS};
 use crate::search::similarity_search::encode_fingerprints;
-use bitvec::macros::internal::funty::Fundamental;
 use rayon::prelude::*;
 use std::{collections::HashMap, fs::File, io::BufRead, io::BufReader, ops::Deref};
 use bitvec::prelude::BitVec;
@@ -246,10 +245,10 @@ fn create_tantivy_doc(
     for field in KNOWN_DESCRIPTORS {
         if let Some(val) = descriptors.get(field) {
             if field.starts_with("Num") || field.starts_with("lipinski") {
-                let int = val.as_f64() as i64;
+                let int = *val as i64;
                 doc.add_field_value(*descriptor_fields.get(field).unwrap(), int);
             } else {
-                doc.add_field_value(*descriptor_fields.get(field).unwrap(), val.as_f64());
+                doc.add_field_value(*descriptor_fields.get(field).unwrap(), *val);
             };
         }
     }

--- a/src/command_line/indexing/bulk_index.rs
+++ b/src/command_line/indexing/bulk_index.rs
@@ -1,8 +1,8 @@
 use crate::command_line::{indexing::split_path, prelude::*};
 use crate::indexing::index_manager::IndexManager;
 use rayon::prelude::*;
-use std::{fs::File, io::BufRead, io::BufReader, ops::Deref};
 use serde_json::Value;
+use std::{fs::File, io::BufRead, io::BufReader, ops::Deref};
 
 pub const NAME: &str = "bulk-index";
 
@@ -56,21 +56,18 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
                 Ok(doc_batch) => {
                     let _ = doc_batch
                         .into_par_iter()
-                        .map(|doc| {
-                            match doc {
-                                Ok(doc) => {
-                                    match writer.add_document(doc) {
-                                        Ok(_) => (),
-                                        Err(_) => {
-                                            log::warn!("Failed doc creation: Could not add document");
-                                        }
-                                    }
-                                },
-                                Err(e) => {
-                                    log::warn!("Failed doc creation: {e}");
+                        .map(|doc| match doc {
+                            Ok(doc) => match writer.add_document(doc) {
+                                Ok(_) => (),
+                                Err(_) => {
+                                    log::warn!("Failed doc creation: Could not add document");
                                 }
+                            },
+                            Err(e) => {
+                                log::warn!("Failed doc creation: {e}");
                             }
-                        }).collect::<Vec<()>>();
+                        })
+                        .collect::<Vec<()>>();
                 }
             }
 
@@ -84,21 +81,18 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
             Ok(doc_batch) => {
                 let _ = doc_batch
                     .into_par_iter()
-                    .map(|doc| {
-                        match doc {
-                            Ok(doc) => {
-                                match writer.add_document(doc) {
-                                    Ok(_) => (),
-                                    Err(_) => {
-                                        log::warn!("Failed doc creation: Could not add document");
-                                    }
-                                }
-                            },
-                            Err(e) => {
-                                log::warn!("Failed doc creation: {e}");
+                    .map(|doc| match doc {
+                        Ok(doc) => match writer.add_document(doc) {
+                            Ok(_) => (),
+                            Err(_) => {
+                                log::warn!("Failed doc creation: Could not add document");
                             }
+                        },
+                        Err(e) => {
+                            log::warn!("Failed doc creation: {e}");
                         }
-                    }).collect::<Vec<()>>();
+                    })
+                    .collect::<Vec<()>>();
             }
         }
 
@@ -110,7 +104,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
     Ok(())
 }
 
-fn get_smiles_and_extra_data(record: &Value) -> eyre::Result<(String, Option<Value>)>{
+fn get_smiles_and_extra_data(record: &Value) -> eyre::Result<(String, Option<Value>)> {
     let smiles = record
         .get("smiles")
         .ok_or(eyre::eyre!("Failed to extract smiles"))?

--- a/src/command_line/indexing/index_sdf.rs
+++ b/src/command_line/indexing/index_sdf.rs
@@ -1,7 +1,7 @@
+use crate::command_line::prelude::*;
 use rayon::prelude::*;
 use rdkit::{MolBlockIter, RWMol};
 use std::sync::{Arc, Mutex};
-use crate::command_line::prelude::*;
 
 pub const NAME: &str = "index-sdf";
 
@@ -111,26 +111,22 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
                 Ok(doc_batch) => {
                     let _ = doc_batch
                         .into_par_iter()
-                        .map(|doc| {
-                            match doc {
-                                Ok(doc) => {
-                                    match index_writer.add_document(doc) {
-                                        Ok(_) => (),
-                                        Err(_) => {
-                                            log::warn!("Failed doc creation: Could not add document");
-                                            let mut num = failed_counter.lock().unwrap();
-                                            *num += 1;
-                                        }
-                                    }
-                                },
-                                Err(e) => {
-                                    log::warn!("Failed doc creation: {e}");
+                        .map(|doc| match doc {
+                            Ok(doc) => match index_writer.add_document(doc) {
+                                Ok(_) => (),
+                                Err(_) => {
+                                    log::warn!("Failed doc creation: Could not add document");
                                     let mut num = failed_counter.lock().unwrap();
                                     *num += 1;
                                 }
+                            },
+                            Err(e) => {
+                                log::warn!("Failed doc creation: {e}");
+                                let mut num = failed_counter.lock().unwrap();
+                                *num += 1;
                             }
-
-                        }).collect::<Vec<()>>();
+                        })
+                        .collect::<Vec<()>>();
 
                     if commit {
                         index_writer.commit()?;
@@ -154,26 +150,22 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
             Ok(doc_batch) => {
                 let _ = doc_batch
                     .into_par_iter()
-                    .map(|doc| {
-                        match doc {
-                            Ok(doc) => {
-                                match index_writer.add_document(doc) {
-                                    Ok(_) => (),
-                                    Err(_) => {
-                                        log::warn!("Failed doc creation: Could not add document");
-                                        let mut num = failed_counter.lock().unwrap();
-                                        *num += 1;
-                                    }
-                                }
-                            },
-                            Err(e) => {
-                                log::warn!("Failed doc creation: {e}");
+                    .map(|doc| match doc {
+                        Ok(doc) => match index_writer.add_document(doc) {
+                            Ok(_) => (),
+                            Err(_) => {
+                                log::warn!("Failed doc creation: Could not add document");
                                 let mut num = failed_counter.lock().unwrap();
                                 *num += 1;
                             }
+                        },
+                        Err(e) => {
+                            log::warn!("Failed doc creation: {e}");
+                            let mut num = failed_counter.lock().unwrap();
+                            *num += 1;
                         }
-
-                    }).collect::<Vec<()>>();
+                    })
+                    .collect::<Vec<()>>();
             }
         }
 

--- a/src/command_line/indexing/index_sdf.rs
+++ b/src/command_line/indexing/index_sdf.rs
@@ -99,7 +99,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         compound_vec.push((mol.to_ro_mol().as_smiles(), None));
 
         if compound_vec.len() == chunksize {
-            match batch_doc_creation(&compound_vec, &schema) {
+            match batch_doc_creation(&compound_vec, schema) {
                 Err(e) => log::warn!("Failed batched doc creation: {e}"),
                 Ok(doc_batch) => {
                     let _ = doc_batch
@@ -142,7 +142,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
 
     if !compound_vec.is_empty() {
         let last_chunksize = compound_vec.len();
-        match batch_doc_creation(&compound_vec, &schema) {
+        match batch_doc_creation(&compound_vec, schema) {
             Err(e) => log::warn!("Failed batched doc creation: {e}"),
             Ok(doc_batch) => {
                 let _ = doc_batch

--- a/src/command_line/indexing/index_sdf.rs
+++ b/src/command_line/indexing/index_sdf.rs
@@ -129,7 +129,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
             );
 
             match doc_batch_result {
-                Err(e) => log::warn!("{e}"),
+                Err(e) => log::warn!("Failed batched doc creation: {e}"),
                 Ok(doc_batch) => {
                     let _ = doc_batch
                         .into_par_iter()

--- a/src/command_line/indexing/index_sdf.rs
+++ b/src/command_line/indexing/index_sdf.rs
@@ -32,6 +32,7 @@ pub fn command() -> Command {
             Arg::new("chunk-size")
                 .required(false)
                 .long("chunk-size")
+                .short('c')
                 .num_args(1),
         )
         .arg(
@@ -50,8 +51,14 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         .get_one::<String>("index")
         .ok_or(eyre::eyre!("Failed to extract index path"))?;
     let limit = matches.get_one::<String>("limit");
-    let chunksize: usize = *matches.get_one("chunk-size").unwrap_or(&1000); // TODO figure out how to parse usize from CLI flags
+    let chunksize = matches.get_one::<String>("chunk-size");
     let commit: bool = matches.get_flag("commit");
+
+    let chunksize = if let Some(chunksize) = chunksize {
+        chunksize.parse::<usize>()?
+    } else {
+        usize::try_from(1000)?
+    };
 
     log::info!(
         "indexing path={}, index_dir={}, limit={:?}",

--- a/src/command_line/search/similarity_search.rs
+++ b/src/command_line/search/similarity_search.rs
@@ -2,8 +2,6 @@ use crate::command_line::prelude::*;
 use crate::search::similarity_search::{neighbor_search, similarity_search};
 use crate::search::{compound_processing::*, validate_structure};
 use std::cmp::min;
-use std::collections::HashSet;
-use tantivy::DocAddress;
 
 pub const NAME: &str = "similarity-search";
 
@@ -133,15 +131,7 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         .map(|m| m.morgan_fingerprint().0)
         .collect::<Vec<_>>();
 
-    let mut results: HashSet<DocAddress> = HashSet::new();
-    for taut_fp in &taut_morgan_fingerprints {
-        let taut_results = neighbor_search(&searcher, taut_fp, &extra_query, search_percent_limit);
-        if let Ok(taut_results) = taut_results {
-            results.extend(taut_results);
-        } else {
-            log::warn!("Encountered a failed search");
-        }
-    }
+    let results = neighbor_search(&searcher, &taut_morgan_fingerprints, &extra_query, search_percent_limit)?;
 
     let final_results = similarity_search(
         &searcher,

--- a/src/command_line/search/similarity_search.rs
+++ b/src/command_line/search/similarity_search.rs
@@ -131,7 +131,12 @@ pub fn action(matches: &ArgMatches) -> eyre::Result<()> {
         .map(|m| m.morgan_fingerprint().0)
         .collect::<Vec<_>>();
 
-    let results = neighbor_search(&searcher, &taut_morgan_fingerprints, &extra_query, search_percent_limit)?;
+    let results = neighbor_search(
+        &searcher,
+        &taut_morgan_fingerprints,
+        &extra_query,
+        search_percent_limit,
+    )?;
 
     let final_results = similarity_search(
         &searcher,

--- a/src/indexing/mod.rs
+++ b/src/indexing/mod.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::{Arc, Mutex};
 use bitvec::prelude::BitVec;
 use rayon::prelude::*;
 use rdkit::{Fingerprint, ROMol};
@@ -126,12 +125,10 @@ pub fn batch_doc_creation(
         .map_err(|e| eyre::eyre!("Failed batched similarity cluster assignment: {e}"))?;
 
     let num_compounds = mol_attributes.len();
-    let mol_attributes = Arc::new(Mutex::new(mol_attributes));
 
     let docs = (0..num_compounds)
-        .into_par_iter()
         .map(|i| {
-            let attributes = &(*mol_attributes.lock().unwrap())[i];
+            let attributes = &mol_attributes[i];
             if attributes.0 == "Passed" {
                 create_tantivy_doc(
                     &attributes.1,

--- a/src/indexing/mod.rs
+++ b/src/indexing/mod.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
 use std::path::Path;
-
+use rdkit::{Fingerprint, ROMol};
 pub use tantivy::doc;
 use tantivy::{directory::MmapDirectory, schema::*, Index, IndexBuilder, TantivyError};
+use crate::search::scaffold_search::{PARSED_SCAFFOLDS, scaffold_search};
 
 pub mod index_manager;
 pub mod segment_manager;
@@ -75,6 +77,58 @@ pub fn open_index(p: impl AsRef<Path>) -> eyre::Result<Index> {
     let index = Index::open(directory)?;
 
     Ok(index)
+}
+
+pub fn create_tantivy_doc(
+    canon_taut: &ROMol,
+    extra_data: &Option<serde_json::Value>,
+    pattern_fp: &Fingerprint,
+    morgan_fp: &Fingerprint,
+    descriptors: &HashMap<String, f64>,
+    similarity_cluster: i32,
+    smiles_field: Field,
+    pattern_fingerprint_field: Field,
+    morgan_fingerprint_field: Field,
+    descriptor_fields: &HashMap<&str, Field>,
+    extra_data_field: Field,
+    other_descriptors_field: Field,
+) -> eyre::Result<impl Document> {
+    let mut doc = doc!(
+        smiles_field => canon_taut.as_smiles(),
+        pattern_fingerprint_field => pattern_fp.0.as_raw_slice(),
+        morgan_fingerprint_field => morgan_fp.0.as_raw_slice(),
+    );
+
+    let scaffold_matches = scaffold_search(&pattern_fp.0, &canon_taut, &PARSED_SCAFFOLDS)?;
+    let scaffold_json = match scaffold_matches.is_empty() {
+        true => serde_json::json!({"scaffolds": vec![-1]}),
+        false => serde_json::json!({"scaffolds": scaffold_matches}),
+    };
+
+    let cluster_json = serde_json::json!({"similarity_cluster": similarity_cluster});
+
+    let other_descriptors_json = combine_json_objects(Some(scaffold_json), Some(cluster_json));
+
+    if let Some(other_descriptors_json) = other_descriptors_json {
+        doc.add_field_value(other_descriptors_field, other_descriptors_json);
+    }
+
+    if let Some(extra_data) = extra_data {
+        doc.add_field_value(extra_data_field, extra_data.clone());
+    }
+
+    for field in KNOWN_DESCRIPTORS {
+        if let Some(val) = descriptors.get(field) {
+            if field.starts_with("Num") || field.starts_with("lipinski") {
+                let int = *val as i64;
+                doc.add_field_value(*descriptor_fields.get(field).unwrap(), int);
+            } else {
+                doc.add_field_value(*descriptor_fields.get(field).unwrap(), *val);
+            };
+        }
+    }
+
+    Ok(doc)
 }
 
 pub fn combine_json_objects(

--- a/src/rest_api/api/indexing/bulk_index.rs
+++ b/src/rest_api/api/indexing/bulk_index.rs
@@ -41,9 +41,11 @@ pub async fn v1_post_index_bulk(
 
     let tantivy_docs = match tantivy_docs_conversion_operation {
         Ok(Ok(docs)) => docs,
-        Ok(Err(e)) => return PostIndexesBulkIndexResponse::Err(Json(PostIndexBulkResponseError {
-            error: e.to_string(),
-        })),
+        Ok(Err(e)) => {
+            return PostIndexesBulkIndexResponse::Err(Json(PostIndexBulkResponseError {
+                error: e.to_string(),
+            }))
+        }
         Err(e) => {
             return PostIndexesBulkIndexResponse::Err(Json(PostIndexBulkResponseError {
                 error: e.to_string(),

--- a/src/rest_api/api/indexing/bulk_index.rs
+++ b/src/rest_api/api/indexing/bulk_index.rs
@@ -1,18 +1,16 @@
-use crate::indexing::{combine_json_objects, index_manager::IndexManager, KNOWN_DESCRIPTORS};
+use crate::indexing::{create_tantivy_doc, index_manager::IndexManager, KNOWN_DESCRIPTORS};
 use crate::rest_api::api::{
     BulkRequest, PostIndexBulkResponseError, PostIndexBulkResponseOk,
     PostIndexBulkResponseOkStatus, PostIndexesBulkIndexResponse,
 };
 use crate::search::compound_processing::process_cpd;
-use crate::search::scaffold_search::{scaffold_search, PARSED_SCAFFOLDS};
 use crate::search::similarity_search::encode_fingerprints;
 use poem_openapi::payload::Json;
 use rayon::prelude::*;
-use serde_json::Value;
 use std::collections::HashMap;
 use bitvec::prelude::BitVec;
-use rdkit::{Fingerprint, ROMol};
-use tantivy::{doc, Document};
+use rdkit::Fingerprint;
+use tantivy::Document;
 use tantivy::schema::{Field, Schema};
 
 pub async fn v1_post_index_bulk(
@@ -166,56 +164,4 @@ fn batch_doc_creation(
         }).collect::<Vec<_>>();
 
     Ok(docs)
-}
-
-fn create_tantivy_doc(
-    canon_taut: &ROMol,
-    extra_data: &Option<Value>,
-    pattern_fp: &Fingerprint,
-    morgan_fp: &Fingerprint,
-    descriptors: &HashMap<String, f64>,
-    similarity_cluster: i32,
-    smiles_field: Field,
-    pattern_fingerprint_field: Field,
-    morgan_fingerprint_field: Field,
-    descriptor_fields: &HashMap<&str, Field>,
-    extra_data_field: Field,
-    other_descriptors_field: Field,
-) -> eyre::Result<impl Document> {
-    let mut doc = doc!(
-        smiles_field => canon_taut.as_smiles(),
-        pattern_fingerprint_field => pattern_fp.0.as_raw_slice(),
-        morgan_fingerprint_field => morgan_fp.0.as_raw_slice(),
-    );
-
-    let scaffold_matches = scaffold_search(&pattern_fp.0, &canon_taut, &PARSED_SCAFFOLDS)?;
-    let scaffold_json = match scaffold_matches.is_empty() {
-        true => serde_json::json!({"scaffolds": vec![-1]}),
-        false => serde_json::json!({"scaffolds": scaffold_matches}),
-    };
-
-    let cluster_json = serde_json::json!({"similarity_cluster": similarity_cluster});
-
-    let other_descriptors_json = combine_json_objects(Some(scaffold_json), Some(cluster_json));
-
-    if let Some(other_descriptors_json) = other_descriptors_json {
-        doc.add_field_value(other_descriptors_field, other_descriptors_json);
-    }
-
-    if let Some(extra_data) = extra_data {
-        doc.add_field_value(extra_data_field, extra_data.clone());
-    }
-
-    for field in KNOWN_DESCRIPTORS {
-        if let Some(val) = descriptors.get(field) {
-            if field.starts_with("Num") || field.starts_with("lipinski") {
-                let int = *val as i64;
-                doc.add_field_value(*descriptor_fields.get(field).unwrap(), int);
-            } else {
-                doc.add_field_value(*descriptor_fields.get(field).unwrap(), *val);
-            };
-        }
-    }
-
-    Ok(doc)
 }

--- a/src/rest_api/api/indexing/bulk_index.rs
+++ b/src/rest_api/api/indexing/bulk_index.rs
@@ -1,17 +1,10 @@
-use crate::indexing::{create_tantivy_doc, index_manager::IndexManager, KNOWN_DESCRIPTORS};
+use crate::indexing::{batch_doc_creation, index_manager::IndexManager};
 use crate::rest_api::api::{
     BulkRequest, PostIndexBulkResponseError, PostIndexBulkResponseOk,
     PostIndexBulkResponseOkStatus, PostIndexesBulkIndexResponse,
 };
-use crate::search::compound_processing::process_cpd;
-use crate::search::similarity_search::encode_fingerprints;
 use poem_openapi::payload::Json;
 use rayon::prelude::*;
-use std::collections::HashMap;
-use bitvec::prelude::BitVec;
-use rdkit::Fingerprint;
-use tantivy::Document;
-use tantivy::schema::{Field, Schema};
 
 pub async fn v1_post_index_bulk(
     index_manager: &IndexManager,
@@ -37,7 +30,12 @@ pub async fn v1_post_index_bulk(
     };
 
     let tantivy_docs_conversion_operation = tokio::task::spawn_blocking(move || {
-        batch_doc_creation(bulk_request, &index.schema())
+        let compounds = bulk_request
+            .docs
+            .into_par_iter()
+            .map(|doc| (doc.smiles, doc.extra_data))
+            .collect::<Vec<_>>();
+        batch_doc_creation(&compounds, &index.schema())
     })
     .await;
 
@@ -94,74 +92,4 @@ pub async fn v1_post_index_bulk(
     PostIndexesBulkIndexResponse::Ok(Json(PostIndexBulkResponseOk {
         statuses: document_insert_statuses,
     }))
-}
-
-fn batch_doc_creation(
-    bulk_request: BulkRequest,
-    schema: &Schema,
-) -> eyre::Result<Vec<eyre::Result<impl Document>>> {
-    let smiles_field = schema.get_field("smiles").unwrap();
-    let pattern_fingerprint_field = schema.get_field("pattern_fingerprint").unwrap();
-    let morgan_fingerprint_field = schema.get_field("morgan_fingerprint").unwrap();
-    let extra_data_field = schema.get_field("extra_data").unwrap();
-    let other_descriptors_field = schema.get_field("other_descriptors").unwrap();
-
-    let descriptor_fields = KNOWN_DESCRIPTORS
-        .iter()
-        .map(|kd| (*kd, schema.get_field(kd).unwrap()))
-        .collect::<HashMap<&str, Field>>();
-
-    let mol_attributes = bulk_request
-        .docs
-        .into_par_iter()
-        .map(|doc| {
-            match process_cpd(&doc.smiles, false) {
-                Ok(attributes) => {
-                    (true, attributes.0, doc.extra_data, attributes.1, attributes.2)
-                },
-                Err(_) => {
-                    let placeholder = process_cpd("c1ccccc1", false).unwrap();
-                    (false, placeholder.0, None, placeholder.1, placeholder.2)
-                }
-            }
-        })
-        .collect::<Vec<_>>();
-
-    let mut morgan_fingerprints: Vec<Fingerprint> = Vec::with_capacity(mol_attributes.len());
-    let mut morgan_bitvecs: Vec<BitVec<u8>> = Vec::with_capacity(mol_attributes.len());
-    for attributes in &mol_attributes {
-        let morgan_fp = attributes.1.morgan_fingerprint();
-        morgan_fingerprints.push(morgan_fp.clone());
-        morgan_bitvecs.push(morgan_fp.0);
-    }
-
-    let similarity_clusters = encode_fingerprints(&morgan_bitvecs, true)
-        .map_err(|e| eyre::eyre!("Failed batched similarity cluster assignment: {e}"))?;
-
-    let docs = (0..mol_attributes.len())
-        .into_iter()
-        .map(|i| {
-            let attributes = &mol_attributes[i];
-            match attributes.0 {
-                true => {
-                    create_tantivy_doc(
-                        &attributes.1,
-                        &attributes.2,
-                        &attributes.3,
-                        &morgan_fingerprints[i],
-                        &attributes.4,
-                        similarity_clusters[i],
-                        smiles_field,
-                        pattern_fingerprint_field,
-                        morgan_fingerprint_field,
-                        &descriptor_fields,
-                        extra_data_field,
-                        other_descriptors_field,
-                    )
-                },
-                false => Err(eyre::eyre!("Compound processing failed")),
-            }
-        }).collect::<Vec<_>>();
-
-    Ok(docs)
 }

--- a/src/rest_api/api/indexing/bulk_index.rs
+++ b/src/rest_api/api/indexing/bulk_index.rs
@@ -137,7 +137,8 @@ fn batch_doc_creation(
         morgan_bitvecs.push(morgan_fp.0);
     }
 
-    let similarity_clusters = encode_fingerprints(&morgan_bitvecs, true)?;
+    let similarity_clusters = encode_fingerprints(&morgan_bitvecs, true)
+        .map_err(|e| eyre::eyre!("Failed batched similarity cluster assignment: {e}"))?;
 
     let docs = (0..mol_attributes.len())
         .into_iter()

--- a/src/rest_api/api/search/similarity_search.rs
+++ b/src/rest_api/api/search/similarity_search.rs
@@ -74,7 +74,13 @@ pub fn v1_index_search_similarity(
         .map(|m| m.morgan_fingerprint().0)
         .collect::<Vec<_>>();
 
-    let results = neighbor_search(&searcher, &taut_morgan_fingerprints, extra_query, search_percent_limit).unwrap_or_else(|e| {
+    let results = neighbor_search(
+        &searcher,
+        &taut_morgan_fingerprints,
+        extra_query,
+        search_percent_limit,
+    )
+    .unwrap_or_else(|e| {
         log::warn!("Encountered a failed search: {e}");
         HashSet::new()
     });

--- a/src/rest_api/api/search/similarity_search.rs
+++ b/src/rest_api/api/search/similarity_search.rs
@@ -5,7 +5,7 @@ use crate::search::{similarity_search::similarity_search, validate_structure};
 use poem_openapi::payload::Json;
 use std::cmp::min;
 use std::collections::HashSet;
-use tantivy::{DocAddress, Index};
+use tantivy::Index;
 
 pub fn v1_index_search_similarity(
     index: eyre::Result<Index>,
@@ -74,15 +74,10 @@ pub fn v1_index_search_similarity(
         .map(|m| m.morgan_fingerprint().0)
         .collect::<Vec<_>>();
 
-    let mut results: HashSet<DocAddress> = HashSet::new();
-    for taut_fp in &taut_morgan_fingerprints {
-        let taut_results = neighbor_search(&searcher, taut_fp, extra_query, search_percent_limit);
-        if let Ok(taut_results) = taut_results {
-            results.extend(taut_results);
-        } else {
-            log::warn!("Encountered a failed search");
-        }
-    }
+    let results = neighbor_search(&searcher, &taut_morgan_fingerprints, extra_query, search_percent_limit).unwrap_or_else(|e| {
+        log::warn!("Encountered a failed search: {e}");
+        HashSet::new()
+    });
 
     let final_results = match similarity_search(
         &searcher,

--- a/src/search/identity_search.rs
+++ b/src/search/identity_search.rs
@@ -12,7 +12,7 @@ use tantivy::{DocAddress, DocId, Searcher, SegmentOrdinal};
 pub fn identity_search(
     searcher: &Searcher,
     query_mol: &ROMol,
-    scaffold_matches: &Option<Vec<u64>>,
+    scaffold_matches: &Option<Vec<i64>>,
     query_pattern_fingerprint: &BitSlice<u8, Lsb0>,
     query_descriptors: &HashMap<String, f64>,
     use_chirality: bool,
@@ -116,7 +116,7 @@ pub fn identity_match(
 pub fn build_identity_query(
     descriptors: &HashMap<String, f64>,
     extra_query: &str,
-    matching_scaffolds: &Option<Vec<u64>>,
+    matching_scaffolds: &Option<Vec<i64>>,
 ) -> String {
     let mut query_parts = Vec::with_capacity(descriptors.len());
 

--- a/src/search/scaffold_search.rs
+++ b/src/search/scaffold_search.rs
@@ -10,7 +10,7 @@ const SCAFFOLDS: &str = include_str!("../../assets/standardized_scaffolds_202404
 pub struct Scaffold {
     pub fp: BitVec<u8>,
     pub mol: Arc<Mutex<ROMol>>,
-    pub idx: u64,
+    pub idx: i64,
 }
 
 lazy_static::lazy_static! {
@@ -29,7 +29,7 @@ lazy_static::lazy_static! {
             mol: Arc::new(Mutex::new(romol)),
             idx: v.get("scaffold_id")
                 .expect("failed to get scaffold_id from static data")
-                .as_u64()
+                .as_i64()
                 .unwrap(),
         }
     })
@@ -40,8 +40,8 @@ pub fn scaffold_search(
     query_pattern_fingerprint: &BitSlice<u8>,
     query_mol: &ROMol,
     scaffolds: &Vec<Scaffold>,
-) -> eyre::Result<Vec<u64>> {
-    let mut matching_scaffolds: Vec<u64> = Vec::with_capacity(scaffolds.len());
+) -> eyre::Result<Vec<i64>> {
+    let mut matching_scaffolds: Vec<i64> = Vec::with_capacity(scaffolds.len());
     let params = SubstructMatchParameters::default();
 
     for scaffold in scaffolds {

--- a/src/search/similarity_search.rs
+++ b/src/search/similarity_search.rs
@@ -139,13 +139,17 @@ pub fn get_tanimoto_similarity(fp1: &BitSlice<u8>, fp2: &BitSlice<u8>) -> f32 {
     and_ones as f32 / or_ones as f32
 }
 
-pub fn encode_fingerprint(bit_vec: &BitVec<u8>, only_best_cluster: bool) -> eyre::Result<Vec<i32>> {
-    let fp_vec = bit_vec
+pub fn encode_fingerprints(bit_vecs: &[BitVec<u8>], only_best_cluster: bool) -> eyre::Result<Vec<i32>> {
+    let fp_vecs = bit_vecs
         .iter()
-        .map(|b| if *b { 1 } else { 0 })
-        .collect::<Vec<u8>>();
+        .map(|bv| {
+            bv
+                .iter()
+                .map(|b| if *b { 1 } else { 0 })
+                .collect::<Vec<i64>>()
+        }).collect::<Vec<Vec<i64>>>();
 
-    let ranked_clusters = build_encoder_model()?.transform(&fp_vec)?;
+    let ranked_clusters = build_encoder_model()?.transform(&fp_vecs)?;
 
     if only_best_cluster {
         Ok(vec![ranked_clusters[0]])

--- a/src/search/similarity_search.rs
+++ b/src/search/similarity_search.rs
@@ -144,15 +144,18 @@ pub fn get_tanimoto_similarity(fp1: &BitSlice<u8>, fp2: &BitSlice<u8>) -> f32 {
     and_ones as f32 / or_ones as f32
 }
 
-pub fn encode_fingerprints(bit_vecs: &[BitVec<u8>], only_best_cluster: bool) -> eyre::Result<Vec<Vec<i32>>> {
+pub fn encode_fingerprints(
+    bit_vecs: &[BitVec<u8>],
+    only_best_cluster: bool,
+) -> eyre::Result<Vec<Vec<i32>>> {
     let fp_vecs = bit_vecs
         .iter()
         .map(|bv| {
-            bv
-                .iter()
+            bv.iter()
                 .map(|b| if *b { 1 } else { 0 })
                 .collect::<Vec<i64>>()
-        }).collect::<Vec<Vec<i64>>>();
+        })
+        .collect::<Vec<Vec<i64>>>();
 
     let ranked_clusters = build_encoder_model()?.transform(&fp_vecs)?;
 

--- a/src/search/structure_search.rs
+++ b/src/search/structure_search.rs
@@ -163,7 +163,7 @@ pub fn structure_match(
 pub fn build_substructure_query(
     descriptors: &HashMap<String, f64>,
     extra_query: &str,
-    matching_scaffolds: &Option<Vec<u64>>,
+    matching_scaffolds: &Option<Vec<i64>>,
 ) -> String {
     let mut query_parts = Vec::with_capacity(descriptors.len());
 
@@ -196,7 +196,7 @@ pub fn build_substructure_query(
 pub fn build_superstructure_query(
     descriptors: &HashMap<String, f64>,
     extra_query: &str,
-    matching_scaffolds: &Option<Vec<u64>>,
+    matching_scaffolds: &Option<Vec<i64>>,
 ) -> String {
     let mut query_parts = Vec::with_capacity(descriptors.len());
 

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use cheminee::indexing::{combine_json_objects, KNOWN_DESCRIPTORS};
 use cheminee::search::compound_processing::process_cpd;
 use cheminee::search::scaffold_search::{scaffold_search, PARSED_SCAFFOLDS};
-use cheminee::search::similarity_search::encode_fingerprint;
+use cheminee::search::similarity_search::encode_fingerprints;
 use poem::test::TestResponse;
 use poem::EndpointExt;
 use poem::{Endpoint, Route};
@@ -139,7 +139,7 @@ fn fill_test_index(tantivy_index: Index) -> eyre::Result<()> {
             false => serde_json::json!({"scaffolds": scaffold_matches}),
         };
 
-        let similarity_cluster = encode_fingerprint(&morgan_fingerprint.0, true)?[0];
+        let similarity_cluster = &encode_fingerprints(&vec![morgan_fingerprint.0], true)?[0];
         let cluster_json = serde_json::json!({"similarity_cluster": similarity_cluster});
 
         let other_descriptors_json = combine_json_objects(Some(scaffold_json), Some(cluster_json));


### PR DESCRIPTION
Resolves [#129](https://github.com/rdkit-rs/cheminee/issues/129). Previously, the tensorflow similarity model was being built for every compound that was indexed (in an effort to avoid null pointer issues in tensorflow rust). Now we are batching the fingerprint encoding step (i.e. relies on tensorflow rust), which significantly cuts down the number of times we rebuild the tensorflow similarity model. Importantly, this still allows us to avoid null pointer issues.

Local tests seem to indicate a 536% improvement in indexing speed for the `index-sdf` CLI endpoint.

**Benchmarks**

Before PR:
```
cargo run --release -- create-index -i tmp/cheminee/test_index_20250107 -n descriptor_v1
time TF_CPP_MIN_LOG_LEVEL=3 cargo run --release -- index-sdf -i tmp/cheminee/test_index_20250107 -s tmp/sdfs/Compound_000000001_000500000.sdf.gz -l 50000

3125.72s user 426.14s system 1103% cpu 5:21.95 total
```

After PR:
```
cargo run --release -- create-index -i tmp/cheminee/test_index_20250107 -n descriptor_v1
time TF_CPP_MIN_LOG_LEVEL=3 cargo run --release -- index-sdf -i tmp/cheminee/test_index_20250107 -s tmp/sdfs/Compound_000000001_000500000.sdf.gz -l 50000

583.29s user 143.53s system 740% cpu 1:38.14 total
```
