### PR TITLE
Implement independent batch size for embedding fingerprints

### DIFF
--- a/src/indexing/mod.rs
+++ b/src/indexing/mod.rs
@@ -138,7 +138,7 @@ pub fn batch_doc_creation(
         })
         .collect::<Vec<_>>();
 
-    let batch_size = 100;
+    let batch_size = 200;
     let num_compounds = mol_attributes.len();
     let num_batches = (num_compounds as f32 / batch_size as f32).ceil() as usize;
     let mut similarity_clusters: Vec<Vec<Vec<i32>>> = Vec::with_capacity(num_batches);


### PR DESCRIPTION
Resolves [#132](https://github.com/rdkit-rs/cheminee/issues/132) by implementing a fingerprint batch size in the `batch_doc_creation` method. This way we limit the size of memory spikes from tensorflow to <2gb on average during compound indexing.