### PR TITLE
Update load test to use scaffold SMILES and reproduce timeout

### DIFF
--- a/examples/clients/ruby-load-test/Gemfile.lock
+++ b/examples/clients/ruby-load-test/Gemfile.lock
@@ -1,16 +1,29 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cheminee (0.1.6)
-      typhoeus (~> 1.0, >= 1.0.1)
-    ethon (0.16.0)
-      ffi (>= 1.15.0)
-    ffi (1.16.3)
-    typhoeus (1.4.0)
-      ethon (>= 0.9.0)
+    cheminee (0.1.48)
+      faraday (>= 1.0.1, < 3.0)
+      faraday-multipart
+      marcel
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-multipart (1.1.0)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
+    json (2.9.1)
+    logger (1.6.4)
+    marcel (1.0.4)
+    multipart-post (2.4.1)
+    net-http (0.6.0)
+      uri
+    uri (1.0.2)
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
 
 DEPENDENCIES
   cheminee

--- a/examples/clients/ruby-load-test/main.rb
+++ b/examples/clients/ruby-load-test/main.rb
@@ -2,26 +2,21 @@
 require 'cheminee'
 
 configuration = Cheminee::Configuration.new()
-# configuration.host = "localhost:3000"
-# configuration.scheme = "http"
-configuration.host = "cheminee.scientist.com"
-configuration.scheme = "https"
+configuration.host = "localhost:4001"
+configuration.scheme = "http"
+configuration.timeout = 300 # 5 minutes
+
+smiles_raw_data = File.read(File.join(File.dirname(__FILE__), '../../../assets/standardized_scaffolds_20240405.json'))
+smiles_data = smiles_raw_data.lines.collect{|l| JSON.parse(l) }
+smiles_data = smiles_data * 50
 
 api_client = Cheminee::ApiClient.new(configuration)
 default_api = Cheminee::DefaultApi.new(api_client)
 
 default_api.v1_indexes_index_post("meepity-beepity", "descriptor_v1", sort_by: "exactmw") rescue nil
 
-structures = File.read("structures").split("\n")
-
-passes = 5
-docs = []
-
-for i in (1..passes)
-  for structure in structures
-    docs << {smiles: structure, extra_data: {smiles_again: structure, notice: "we're on pass #{i}"}}
-  end
+smiles_data.each_slice(10_000).each do |chunk|
+  docs = chunk.map{|smiles| {smiles: smiles["smiles"], extra_data: {compound_id: 123} } }
+  bulk_request = Cheminee::BulkRequest.build_from_hash(docs: docs)
+  result = default_api.v1_indexes_index_bulk_index_post("meepity-beepity", bulk_request)
 end
-
-bulk_request = Cheminee::BulkRequest.build_from_hash(docs: docs)
-result = default_api.v1_indexes_index_bulk_index_post("meepity-beepity", bulk_request)


### PR DESCRIPTION
Our production application was throwing some Faraday::Timeout exception on big uploads. The cheminee rest-api does not enforce any timeouts or size limits, so I was pretty sure it wasn't on the rust side. Turns out the default in Faraday inherits its defaults from Net::HTTP. The Net::HTTP defaults are 60 seconds.

This load test example is just for my ruby friends to understand configuration details.