### PR TITLE
Add a stateless /v1/scaffold_network endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,9 +2445,8 @@ dependencies = [
 
 [[package]]
 name = "rdkit"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b94d33c6331acb09551b75ba29db37b4da4b53a9573d79bb9c882177a921773"
+version = "0.4.13"
+source = "git+https://github.com/rdkit-rs/rdkit?branch=scaffold_network_generator#907b7f83679b295fd6744ea2a2e36058ce436421"
 dependencies = [
  "bitvec",
  "byteorder",
@@ -2460,9 +2459,8 @@ dependencies = [
 
 [[package]]
 name = "rdkit-sys"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af98a4105fe690dcd8baa743f4e25e5c3807fa13a29878f39aefb9e82daf727"
+version = "0.4.13"
+source = "git+https://github.com/rdkit-rs/rdkit?branch=scaffold_network_generator#907b7f83679b295fd6744ea2a2e36058ce436421"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ poem-openapi = { version = "2", features = ["swagger-ui"] }
 poem-openapi-derive = "2"
 rand = "0.8.5"
 rayon = "1"
-rdkit = { version = "0.4.11" }
+# TODO: back to a released version once rdkit-rs/rdkit#56 lands -> rdkit = { version = "0.4.13" }
+rdkit = { git = "https://github.com/rdkit-rs/rdkit", branch = "scaffold_network_generator" }
 regex = "1"
 reqwest = "0"
 serde = { version = "1", features = ["derive"] }

--- a/src/rest_api/api/api_v1.rs
+++ b/src/rest_api/api/api_v1.rs
@@ -3,11 +3,12 @@ use crate::rest_api::api::{
     v1_convert_mol_block_to_smiles, v1_convert_smiles_to_mol_block, v1_delete_index,
     v1_delete_index_bulk, v1_get_index, v1_index_search_basic, v1_index_search_identity,
     v1_index_search_similarity, v1_index_search_structure, v1_list_indexes, v1_list_schemas,
-    v1_merge_segments, v1_post_index, v1_post_index_bulk, v1_standardize, BulkRequest,
-    ConvertedMolBlockResponse, ConvertedSmilesResponse, DeleteIndexResponse,
+    v1_merge_segments, v1_post_index, v1_post_index_bulk, v1_scaffold_network, v1_standardize,
+    BulkRequest, ConvertedMolBlockResponse, ConvertedSmilesResponse, DeleteIndexResponse,
     DeleteIndexesBulkDeleteResponse, GetIndexResponse, GetQuerySearchResponse,
     GetStructureSearchResponse, ListIndexesResponse, ListSchemasResponse, MergeSegmentsResponse,
-    PostIndexResponse, PostIndexesBulkIndexResponse, StandardizeResponse,
+    PostIndexResponse, PostIndexesBulkIndexResponse, ScaffoldNetworkRequest,
+    ScaffoldNetworkResponse, StandardizeResponse,
 };
 use crate::rest_api::models::{MolBlock, Smiles};
 
@@ -50,6 +51,20 @@ impl ApiV1 {
         smiles_vec: Json<Vec<Smiles>>,
     ) -> ConvertedMolBlockResponse {
         v1_convert_smiles_to_mol_block(smiles_vec).await
+    }
+
+    #[oai(path = "/v1/scaffold_network", method = "post")]
+    /// Compute the scaffold hierarchy for a list of SMILES
+    ///
+    /// Each molecule is fragmented into its scaffold network: a DAG whose nodes are
+    /// canonical scaffold SMILES and whose edges point from a more specific scaffold up to
+    /// a more general one. This is stateless and touches no index. A molecule that cannot
+    /// be processed comes back with its `error` set and the rest of the batch unaffected.
+    pub async fn v1_scaffold_network(
+        &self,
+        request: Json<ScaffoldNetworkRequest>,
+    ) -> ScaffoldNetworkResponse {
+        v1_scaffold_network(request.0).await
     }
 
     #[oai(path = "/v1/schemas", method = "get")]

--- a/src/rest_api/api/mod.rs
+++ b/src/rest_api/api/mod.rs
@@ -9,6 +9,9 @@ pub use search::*;
 
 mod compound_processing;
 
+mod scaffold_network;
+pub use scaffold_network::*;
+
 mod response_types;
 pub use response_types::*;
 

--- a/src/rest_api/api/response_types.rs
+++ b/src/rest_api/api/response_types.rs
@@ -1,3 +1,4 @@
+use crate::search::scaffold_network::ScaffoldNetworkResult;
 use crate::search::{QuerySearchHit, StructureSearchHit};
 use poem_openapi::{payload::Json, ApiResponse, Object};
 use tantivy::Opstamp;
@@ -19,6 +20,17 @@ pub enum ConvertedSmilesResponse {
 pub enum ConvertedMolBlockResponse {
     #[oai(status = "200", content_type = "application/json")]
     Ok(Json<Vec<ConvertedMolBlock>>),
+}
+
+/// A molecule that cannot be processed comes back inside the 200 with its `error` set, so
+/// one bad input never sinks the batch. The 500 is reserved for the compute task itself
+/// falling over.
+#[derive(ApiResponse, Debug)]
+pub enum ScaffoldNetworkResponse {
+    #[oai(status = "200", content_type = "application/json")]
+    Ok(Json<Vec<ScaffoldNetworkResult>>),
+    #[oai(status = "500", content_type = "application/json")]
+    Err(Json<crate::rest_api::api::ScaffoldNetworkResponseError>),
 }
 
 #[derive(ApiResponse, Debug)]
@@ -152,6 +164,53 @@ pub struct BulkRequestDoc {
     pub smiles: String,
     /// This value can store an arbitrary JSON object like '{}'
     pub extra_data: Option<serde_json::Value>,
+}
+
+#[derive(Object, Debug)]
+pub struct ScaffoldNetworkRequest {
+    /// The molecules to fragment. Every entry gets its own entry in the response, in the
+    /// same order.
+    pub smiles: Vec<crate::rest_api::models::Smiles>,
+    pub params: Option<crate::rest_api::api::ScaffoldNetworkParams>,
+}
+
+/// Overrides for the scaffold network computation. Anything left unset keeps RDKit's own
+/// default, which is what the HierS-style hierarchy is usually built from.
+#[derive(Object, Debug)]
+pub struct ScaffoldNetworkParams {
+    /// Also emit each scaffold with every atom replaced by a dummy. On by default in
+    /// RDKit, and worth turning off if you only want concrete scaffolds.
+    pub include_generic_scaffolds: Option<bool>,
+    /// Also emit each scaffold with every bond replaced by a single bond.
+    pub include_generic_bond_scaffolds: Option<bool>,
+    /// Emit scaffolds that still carry their attachment points.
+    pub include_scaffolds_with_attachments: Option<bool>,
+    /// Emit scaffolds with the attachment points stripped off.
+    pub include_scaffolds_without_attachments: Option<bool>,
+    pub keep_only_first_fragment: Option<bool>,
+    pub prune_before_fragmenting: Option<bool>,
+    pub flatten_isotopes: Option<bool>,
+    pub flatten_chirality: Option<bool>,
+    pub flatten_keep_largest: Option<bool>,
+    /// Populate `mol_count` on each node.
+    pub collect_mol_counts: Option<bool>,
+    /// Reaction SMARTS used to cut the molecule apart. Leaving this unset keeps RDKit's
+    /// default; passing an empty list means nothing is ever cut and every network comes
+    /// back as a single node.
+    pub bond_breaker_smarts: Option<Vec<String>>,
+    /// Run each input through the same standardization as /v1/standardize before
+    /// fragmenting. Defaults to true; turn it off when the inputs are already canonical,
+    /// since tautomer canonicalization dominates the cost of the whole call.
+    pub standardize: Option<bool>,
+    /// Reject molecules with more than this many heavy atoms.
+    pub max_atoms: Option<u32>,
+    /// Report an error instead of returning a network with more nodes than this.
+    pub max_nodes: Option<u32>,
+}
+
+#[derive(Object, Debug)]
+pub struct ScaffoldNetworkResponseError {
+    pub error: String,
 }
 
 #[derive(Object, Debug)]

--- a/src/rest_api/api/scaffold_network/compute_scaffold_network.rs
+++ b/src/rest_api/api/scaffold_network/compute_scaffold_network.rs
@@ -1,0 +1,48 @@
+use crate::rest_api::api::{
+    ScaffoldNetworkRequest, ScaffoldNetworkResponse, ScaffoldNetworkResponseError,
+};
+use crate::search::scaffold_network::{scaffold_networks_for_smiles, ScaffoldNetworkOptions};
+use poem_openapi::payload::Json;
+
+pub async fn v1_scaffold_network(request: ScaffoldNetworkRequest) -> ScaffoldNetworkResponse {
+    let options = request
+        .params
+        .map(|p| ScaffoldNetworkOptions {
+            include_generic_scaffolds: p.include_generic_scaffolds,
+            include_generic_bond_scaffolds: p.include_generic_bond_scaffolds,
+            include_scaffolds_with_attachments: p.include_scaffolds_with_attachments,
+            include_scaffolds_without_attachments: p.include_scaffolds_without_attachments,
+            keep_only_first_fragment: p.keep_only_first_fragment,
+            prune_before_fragmenting: p.prune_before_fragmenting,
+            flatten_isotopes: p.flatten_isotopes,
+            flatten_chirality: p.flatten_chirality,
+            flatten_keep_largest: p.flatten_keep_largest,
+            collect_mol_counts: p.collect_mol_counts,
+            bond_breaker_smarts: p.bond_breaker_smarts,
+            standardize: p.standardize,
+            max_atoms: p.max_atoms,
+            max_nodes: p.max_nodes,
+        })
+        .unwrap_or_default();
+
+    let smiles_vec = request
+        .smiles
+        .into_iter()
+        .map(|s| s.smiles)
+        .collect::<Vec<_>>();
+
+    // fragmenting is CPU bound work in RDKit that cannot be interrupted, so it goes on the
+    // blocking pool rather than tying up an async worker for the length of the batch
+    let networks =
+        tokio::task::spawn_blocking(move || scaffold_networks_for_smiles(&smiles_vec, &options))
+            .await;
+
+    match networks {
+        Ok(networks) => ScaffoldNetworkResponse::Ok(Json(networks)),
+        // per-molecule failures are already reported inside the 200, so getting here means
+        // the blocking task itself died and there is nothing partial worth returning
+        Err(e) => ScaffoldNetworkResponse::Err(Json(ScaffoldNetworkResponseError {
+            error: e.to_string(),
+        })),
+    }
+}

--- a/src/rest_api/api/scaffold_network/mod.rs
+++ b/src/rest_api/api/scaffold_network/mod.rs
@@ -1,0 +1,2 @@
+mod compute_scaffold_network;
+pub use compute_scaffold_network::*;

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -12,6 +12,7 @@ use tantivy::{DocAddress, DocId, Searcher, SegmentOrdinal};
 pub mod basic_search;
 pub mod compound_processing;
 pub mod identity_search;
+pub mod scaffold_network;
 pub mod scaffold_search;
 pub mod similarity_search;
 pub mod structure_matching;

--- a/src/search/scaffold_network.rs
+++ b/src/search/scaffold_network.rs
@@ -1,0 +1,286 @@
+use crate::search::compound_processing::standardize_smiles;
+use poem_openapi_derive::Object;
+use rdkit::{scaffold_network_for_mol, ROMol, ScaffoldNetworkEdgeType, ScaffoldNetworkParams};
+
+/// Molecules bigger than this are rejected before RDKit is handed anything, because the
+/// cost of enumerating a scaffold hierarchy climbs with the number of ring systems and
+/// there is no way to interrupt RDKit once it is running.
+pub const DEFAULT_MAX_ATOMS: u32 = 150;
+
+/// A network larger than this is reported as an error rather than returned, which keeps a
+/// single pathological input from dominating a batch response.
+pub const DEFAULT_MAX_NODES: u32 = 5_000;
+
+/// Knobs for one scaffold network computation. `None` everywhere means RDKit's own
+/// defaults plus the limits above.
+#[derive(Debug, Default, Clone)]
+pub struct ScaffoldNetworkOptions {
+    pub include_generic_scaffolds: Option<bool>,
+    pub include_generic_bond_scaffolds: Option<bool>,
+    pub include_scaffolds_with_attachments: Option<bool>,
+    pub include_scaffolds_without_attachments: Option<bool>,
+    pub keep_only_first_fragment: Option<bool>,
+    pub prune_before_fragmenting: Option<bool>,
+    pub flatten_isotopes: Option<bool>,
+    pub flatten_chirality: Option<bool>,
+    pub flatten_keep_largest: Option<bool>,
+    pub collect_mol_counts: Option<bool>,
+    pub bond_breaker_smarts: Option<Vec<String>>,
+    pub standardize: Option<bool>,
+    pub max_atoms: Option<u32>,
+    pub max_nodes: Option<u32>,
+}
+
+impl ScaffoldNetworkOptions {
+    fn max_atoms(&self) -> u32 {
+        self.max_atoms.unwrap_or(DEFAULT_MAX_ATOMS)
+    }
+
+    fn max_nodes(&self) -> u32 {
+        self.max_nodes.unwrap_or(DEFAULT_MAX_NODES)
+    }
+
+    fn rdkit_params(&self) -> ScaffoldNetworkParams {
+        let mut params = match &self.bond_breaker_smarts {
+            Some(smarts) => ScaffoldNetworkParams::with_bond_breakers(smarts),
+            None => ScaffoldNetworkParams::default(),
+        };
+
+        if let Some(what) = self.include_generic_scaffolds {
+            params.set_include_generic_scaffolds(what);
+        }
+        if let Some(what) = self.include_generic_bond_scaffolds {
+            params.set_include_generic_bond_scaffolds(what);
+        }
+        if let Some(what) = self.include_scaffolds_with_attachments {
+            params.set_include_scaffolds_with_attachments(what);
+        }
+        if let Some(what) = self.include_scaffolds_without_attachments {
+            params.set_include_scaffolds_without_attachments(what);
+        }
+        if let Some(what) = self.keep_only_first_fragment {
+            params.set_keep_only_first_fragment(what);
+        }
+        if let Some(what) = self.prune_before_fragmenting {
+            params.set_prune_before_fragmenting(what);
+        }
+        if let Some(what) = self.flatten_isotopes {
+            params.set_flatten_isotopes(what);
+        }
+        if let Some(what) = self.flatten_chirality {
+            params.set_flatten_chirality(what);
+        }
+        if let Some(what) = self.flatten_keep_largest {
+            params.set_flatten_keep_largest(what);
+        }
+        if let Some(what) = self.collect_mol_counts {
+            params.set_collect_mol_counts(what);
+        }
+
+        params
+    }
+}
+
+#[derive(Object, Debug, Clone, PartialEq)]
+pub struct ScaffoldNetworkNode {
+    /// Canonical SMILES for the scaffold. A molecule with no rings at all reduces to an
+    /// empty scaffold, so this is legitimately the empty string for those.
+    pub scaffold_smiles: String,
+    /// Every atom in this scaffold has been replaced by a dummy atom.
+    pub is_generic: bool,
+    /// This scaffold still carries the attachment points where it was cut away from its
+    /// parent.
+    pub has_attachments: bool,
+    /// How many times this scaffold was reached while walking the hierarchy.
+    pub count: u32,
+    /// How many input molecules this scaffold was found in. Absent when
+    /// `collect_mol_counts` was turned off.
+    #[oai(skip_serializing_if_is_none)]
+    pub mol_count: Option<u32>,
+}
+
+/// One "is a more specific version of" link, always pointing from the child up to its
+/// more general parent.
+#[derive(Object, Debug, Clone, PartialEq)]
+pub struct ScaffoldNetworkEdge {
+    /// Index into `nodes` of the more general scaffold.
+    pub parent_idx: u32,
+    /// Index into `nodes` of the more specific scaffold.
+    pub child_idx: u32,
+    /// Canonical SMILES of `nodes[parent_idx]`, repeated here so an edge stands on its own.
+    pub parent_smiles: String,
+    /// Canonical SMILES of `nodes[child_idx]`, repeated here so an edge stands on its own.
+    pub child_smiles: String,
+    /// What RDKit did to get from the child to the parent: `Fragment`, `Generic`,
+    /// `GenericBond`, `RemoveAttachment` or `Initialize`.
+    pub edge_type: String,
+}
+
+#[derive(Object, Debug, Clone, PartialEq)]
+pub struct ScaffoldNetworkResult {
+    /// The SMILES as submitted, so results can be lined up with inputs.
+    pub smiles: String,
+    /// The SMILES actually fragmented, after standardization.
+    #[oai(skip_serializing_if_is_none)]
+    pub standardized_smiles: Option<String>,
+    pub nodes: Vec<ScaffoldNetworkNode>,
+    pub edges: Vec<ScaffoldNetworkEdge>,
+    /// Set when this molecule could not be processed. The other fields are empty and the
+    /// rest of the batch is unaffected.
+    #[oai(skip_serializing_if_is_none)]
+    pub error: Option<String>,
+}
+
+impl ScaffoldNetworkResult {
+    fn failed(smiles: &str, error: impl std::fmt::Display) -> Self {
+        ScaffoldNetworkResult {
+            smiles: smiles.to_string(),
+            standardized_smiles: None,
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            error: Some(error.to_string()),
+        }
+    }
+}
+
+/// Build the scaffold hierarchy for a single SMILES. Every failure mode — an unparseable
+/// SMILES, a molecule too big to be worth fragmenting, a network that came out too large,
+/// or an exception from RDKit itself — comes back as `Err` for the caller to report
+/// per-molecule rather than failing the whole batch.
+pub fn scaffold_network_for_smiles(
+    smiles: &str,
+    options: &ScaffoldNetworkOptions,
+) -> eyre::Result<ScaffoldNetworkResult> {
+    let standardize = options.standardize.unwrap_or(true);
+
+    let romol = match standardize {
+        true => standardize_smiles(smiles, false)?,
+        false => ROMol::from_smiles(smiles).map_err(|e| eyre::eyre!("{}", e))?,
+    };
+
+    // RDKit runs to completion once it starts and cannot be interrupted, so the only real
+    // protection against a pathological input is to refuse it up front
+    let num_atoms = romol.num_atoms(true);
+    if num_atoms > options.max_atoms() {
+        return Err(eyre::eyre!(
+            "molecule has {num_atoms} atoms, more than the {} allowed",
+            options.max_atoms()
+        ));
+    }
+
+    let standardized_smiles = romol.as_smiles();
+    let network = scaffold_network_for_mol(&romol, &options.rdkit_params())
+        .map_err(|e| eyre::eyre!("{}", e))?;
+
+    if network.nodes.len() > options.max_nodes() as usize {
+        return Err(eyre::eyre!(
+            "scaffold network has {} nodes, more than the {} allowed",
+            network.nodes.len(),
+            options.max_nodes()
+        ));
+    }
+
+    let attachment_flags = attachment_flags(&network);
+
+    let nodes = network
+        .nodes
+        .iter()
+        .enumerate()
+        .map(|(idx, node)| ScaffoldNetworkNode {
+            scaffold_smiles: node.scaffold_smiles.clone(),
+            is_generic: attachment_flags[idx].is_generic,
+            has_attachments: attachment_flags[idx].has_attachments,
+            count: node.count,
+            mol_count: node.mol_count,
+        })
+        .collect::<Vec<_>>();
+
+    let edges = network
+        .edges
+        .iter()
+        .map(|edge| ScaffoldNetworkEdge {
+            parent_idx: edge.parent_idx() as u32,
+            child_idx: edge.child_idx() as u32,
+            parent_smiles: network.nodes[edge.parent_idx()].scaffold_smiles.clone(),
+            child_smiles: network.nodes[edge.child_idx()].scaffold_smiles.clone(),
+            edge_type: edge.edge_type.to_string(),
+        })
+        .collect::<Vec<_>>();
+
+    Ok(ScaffoldNetworkResult {
+        smiles: smiles.to_string(),
+        standardized_smiles: Some(standardized_smiles),
+        nodes,
+        edges,
+        error: None,
+    })
+}
+
+#[derive(Default, Clone, Copy)]
+struct NodeFlags {
+    is_generic: bool,
+    has_attachments: bool,
+}
+
+/// Work out which nodes are dummy-atom scaffolds and which still carry attachment points,
+/// using the edges RDKit already labelled rather than re-parsing the scaffold SMILES.
+/// Re-parsing would mean handing RDKit a generic SMILES like `*1:*:*:*:*:*:1`, and the
+/// property-cache invariants it trips on there abort the process instead of raising.
+///
+/// RDKit only ever reaches a generic scaffold through a `Generic`/`GenericBond` edge, and
+/// only ever strips attachment points through a `RemoveAttachment` edge, so:
+///
+///   * a node is generic exactly when a generic edge points at it
+///   * a node has attachments exactly when a `RemoveAttachment` edge leaves it, or when it
+///     is the generic twin of a node that does
+///
+/// This needs two passes, not one: RDKit emits a node's `Generic` edge before its
+/// `RemoveAttachment` edge, so propagating during the first pass would read the attachment
+/// flag before it had been set.
+fn attachment_flags(network: &rdkit::ScaffoldNetwork) -> Vec<NodeFlags> {
+    let mut flags = vec![NodeFlags::default(); network.nodes.len()];
+
+    for edge in &network.edges {
+        match edge.edge_type {
+            ScaffoldNetworkEdgeType::RemoveAttachment => {
+                flags[edge.child_idx()].has_attachments = true
+            }
+            ScaffoldNetworkEdgeType::Generic | ScaffoldNetworkEdgeType::GenericBond => {
+                flags[edge.parent_idx()].is_generic = true
+            }
+            _ => (),
+        }
+    }
+
+    for edge in &network.edges {
+        if matches!(
+            edge.edge_type,
+            ScaffoldNetworkEdgeType::Generic | ScaffoldNetworkEdgeType::GenericBond
+        ) {
+            // a generic scaffold keeps whatever attachment points its concrete twin had,
+            // and the same generic can be reached from more than one twin
+            flags[edge.parent_idx()].has_attachments |= flags[edge.child_idx()].has_attachments;
+        }
+    }
+
+    flags
+}
+
+/// Run a batch of SMILES through [`scaffold_network_for_smiles`], turning per-molecule
+/// failures into per-molecule errors so one bad input cannot sink the batch.
+pub fn scaffold_networks_for_smiles(
+    smiles_vec: &[String],
+    options: &ScaffoldNetworkOptions,
+) -> Vec<ScaffoldNetworkResult> {
+    use rayon::prelude::*;
+
+    smiles_vec
+        .par_iter()
+        .map(
+            |smiles| match scaffold_network_for_smiles(smiles, options) {
+                Ok(result) => result,
+                Err(e) => ScaffoldNetworkResult::failed(smiles, e),
+            },
+        )
+        .collect::<Vec<_>>()
+}

--- a/src/search/scaffold_network.rs
+++ b/src/search/scaffold_network.rs
@@ -1,3 +1,16 @@
+//! Scaffold networks: the hierarchy of ring systems and linkers a molecule reduces to,
+//! computed by RDKit's `rdScaffoldNetwork`.
+//!
+//! Prior art for this class of hierarchy, though not the algorithm RDKit implements:
+//! Wilkens, Janes & Su, "HierS: hierarchical scaffold clustering using topological
+//! chemical graphs", J. Med. Chem. 2005, 48(9), 3182-93, doi:10.1021/jm049032d. HierS
+//! enumerates ring-delimited substructures directly, where RDKit applies a bond breaking
+//! reaction and also emits the generic and attachment point scaffolds seen in the node
+//! flags below, which HierS has no equivalent of.
+//!
+//! Not to be confused with [`crate::search::scaffold_search`], which matches against a
+//! static precomputed dictionary of scaffolds to accelerate tantivy queries.
+
 use crate::search::compound_processing::standardize_smiles;
 use poem_openapi_derive::Object;
 use rdkit::{scaffold_network_for_mol, ROMol, ScaffoldNetworkEdgeType, ScaffoldNetworkParams};

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -656,3 +656,212 @@ async fn test_standardization_with_attempt_fix() -> eyre::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_scaffold_network() -> eyre::Result<()> {
+    let (test_client, _) = build_test_client()?;
+
+    // benzene is already its own scaffold, so with the dummy-atom scaffolds turned off the
+    // whole network is one node and no edges
+    let response = test_client
+        .post("/api/v1/scaffold_network")
+        .body_json(&serde_json::json!({
+            "smiles": [{"smiles": "c1ccccc1"}],
+            "params": {
+                "include_generic_scaffolds": false,
+                "include_generic_bond_scaffolds": false
+            }
+        }))
+        .send()
+        .await;
+    response.assert_status_is_ok();
+    response
+        .assert_json(&serde_json::json!([{
+            "smiles": "c1ccccc1",
+            "standardized_smiles": "c1ccccc1",
+            "nodes": [{
+                "scaffold_smiles": "c1ccccc1",
+                "is_generic": false,
+                "has_attachments": false,
+                "count": 1,
+                "mol_count": 1
+            }],
+            "edges": []
+        }]))
+        .await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_scaffold_network_multi_ring() -> eyre::Result<()> {
+    let (test_client, _) = build_test_client()?;
+
+    let mut response = test_client
+        .post("/api/v1/scaffold_network")
+        .body_json(&serde_json::json!({
+            "smiles": [{"smiles": "c1ccc(-c2ccc3ncccc3c2)cc1"}],
+            "params": {
+                "include_generic_scaffolds": false,
+                "include_generic_bond_scaffolds": false
+            }
+        }))
+        .send()
+        .await;
+    response.assert_status_is_ok();
+
+    let body: serde_json::Value =
+        serde_json::from_slice(&response.0.take_body().into_bytes().await?)?;
+    let result = &body[0];
+
+    // the whole molecule, both ring systems with and without their attachment points
+    let scaffolds = result["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|n| n["scaffold_smiles"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        scaffolds,
+        [
+            "c1ccc(-c2ccc3ncccc3c2)cc1",
+            "*c1ccccc1",
+            "c1ccccc1",
+            "*c1ccc2ncccc2c1",
+            "c1ccc2ncccc2c1",
+        ]
+    );
+
+    // and every edge names both ends, so the hierarchy can be walked without the indices
+    let edges = result["edges"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| {
+            (
+                e["child_smiles"].as_str().unwrap(),
+                e["parent_smiles"].as_str().unwrap(),
+                e["edge_type"].as_str().unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        edges,
+        [
+            ("c1ccc(-c2ccc3ncccc3c2)cc1", "*c1ccccc1", "Fragment"),
+            ("*c1ccccc1", "c1ccccc1", "RemoveAttachment"),
+            ("c1ccc(-c2ccc3ncccc3c2)cc1", "*c1ccc2ncccc2c1", "Fragment"),
+            ("*c1ccc2ncccc2c1", "c1ccc2ncccc2c1", "RemoveAttachment"),
+        ]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_scaffold_network_bad_smiles_is_per_item() -> eyre::Result<()> {
+    let (test_client, _) = build_test_client()?;
+
+    // a bad input is reported against that input only; the batch still returns 200
+    let response = test_client
+        .post("/api/v1/scaffold_network")
+        .body_json(&serde_json::json!({
+            "smiles": [
+                {"smiles": "not-a-smiles"},
+                {"smiles": "c1ccccc1"}
+            ],
+            "params": {
+                "include_generic_scaffolds": false,
+                "include_generic_bond_scaffolds": false
+            }
+        }))
+        .send()
+        .await;
+    response.assert_status_is_ok();
+    response
+        .assert_json(&serde_json::json!([
+            {
+                "smiles": "not-a-smiles",
+                "nodes": [],
+                "edges": [],
+                "error": "could not convert smiles to romol (nullptr)"
+            },
+            {
+                "smiles": "c1ccccc1",
+                "standardized_smiles": "c1ccccc1",
+                "nodes": [{
+                    "scaffold_smiles": "c1ccccc1",
+                    "is_generic": false,
+                    "has_attachments": false,
+                    "count": 1,
+                    "mol_count": 1
+                }],
+                "edges": []
+            }
+        ]))
+        .await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_scaffold_network_params_change_output() -> eyre::Result<()> {
+    let (test_client, _) = build_test_client()?;
+
+    async fn node_count(
+        test_client: &poem::test::TestClient<impl Endpoint>,
+        params: serde_json::Value,
+    ) -> eyre::Result<usize> {
+        let mut response = test_client
+            .post("/api/v1/scaffold_network")
+            .body_json(&serde_json::json!({
+                "smiles": [{"smiles": "c1ccc(-c2ccc3ncccc3c2)cc1"}],
+                "params": params
+            }))
+            .send()
+            .await;
+        response.assert_status_is_ok();
+        let body: serde_json::Value =
+            serde_json::from_slice(&response.0.take_body().into_bytes().await?)?;
+        Ok(body[0]["nodes"].as_array().unwrap().len())
+    }
+
+    // RDKit emits the dummy-atom scaffolds by default, which nearly doubles the node count
+    let with_generics = node_count(&test_client, serde_json::json!({})).await?;
+    let without_generics = node_count(
+        &test_client,
+        serde_json::json!({"include_generic_scaffolds": false, "include_generic_bond_scaffolds": false}),
+    )
+    .await?;
+
+    assert_eq!(with_generics, 9);
+    assert_eq!(without_generics, 5);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_scaffold_network_respects_limits() -> eyre::Result<()> {
+    let (test_client, _) = build_test_client()?;
+
+    // an oversized molecule is refused before RDKit is handed anything, and says so
+    // against that molecule rather than failing the request
+    let mut response = test_client
+        .post("/api/v1/scaffold_network")
+        .body_json(&serde_json::json!({
+            "smiles": [{"smiles": "c1ccc(-c2ccc3ncccc3c2)cc1"}],
+            "params": {"max_atoms": 5}
+        }))
+        .send()
+        .await;
+    response.assert_status_is_ok();
+
+    let body: serde_json::Value =
+        serde_json::from_slice(&response.0.take_body().into_bytes().await?)?;
+    assert_eq!(
+        body[0]["error"].as_str(),
+        Some("molecule has 16 atoms, more than the 5 allowed")
+    );
+
+    Ok(())
+}

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -1,6 +1,10 @@
 use bitvec::store::BitStore;
 use cheminee::search::compound_processing::{process_cpd, standardize_smiles};
 use cheminee::search::identity_search::{build_identity_query, identity_search};
+use cheminee::search::scaffold_network::{
+    scaffold_network_for_smiles, scaffold_networks_for_smiles, ScaffoldNetworkOptions,
+    ScaffoldNetworkResult,
+};
 use cheminee::search::scaffold_search::{scaffold_search, PARSED_SCAFFOLDS};
 use cheminee::search::similarity_search::build_similarity_query;
 use cheminee::search::structure_search::{
@@ -300,4 +304,203 @@ fn test_superstructure_search() {
     .unwrap();
 
     assert_eq!(results.len(), 1);
+}
+
+/// 2-phenylquinoline: one fused bicycle plus a pendant ring, so the hierarchy has
+/// something in it.
+const PHENYLQUINOLINE: &str = "c1ccc(-c2ccc3ncccc3c2)cc1";
+
+fn scaffold_smiles(result: &ScaffoldNetworkResult) -> Vec<&str> {
+    result
+        .nodes
+        .iter()
+        .map(|n| n.scaffold_smiles.as_str())
+        .collect()
+}
+
+fn no_generics() -> ScaffoldNetworkOptions {
+    ScaffoldNetworkOptions {
+        include_generic_scaffolds: Some(false),
+        include_generic_bond_scaffolds: Some(false),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_scaffold_network_hierarchy() {
+    let result = scaffold_network_for_smiles(PHENYLQUINOLINE, &no_generics()).unwrap();
+
+    assert_eq!(result.smiles, PHENYLQUINOLINE);
+    assert_eq!(result.standardized_smiles.as_deref(), Some(PHENYLQUINOLINE));
+    assert_eq!(result.error, None);
+    assert_eq!(
+        scaffold_smiles(&result),
+        [
+            PHENYLQUINOLINE,
+            "*c1ccccc1",
+            "c1ccccc1",
+            "*c1ccc2ncccc2c1",
+            "c1ccc2ncccc2c1",
+        ]
+    );
+
+    // every edge points from the more specific scaffold up to the more general one, and
+    // carries both SMILES so an edge can be consumed without the node list
+    let hierarchy = result
+        .edges
+        .iter()
+        .map(|e| (e.child_smiles.as_str(), e.parent_smiles.as_str()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        hierarchy,
+        [
+            (PHENYLQUINOLINE, "*c1ccccc1"),
+            ("*c1ccccc1", "c1ccccc1"),
+            (PHENYLQUINOLINE, "*c1ccc2ncccc2c1"),
+            ("*c1ccc2ncccc2c1", "c1ccc2ncccc2c1"),
+        ]
+    );
+
+    // and the indices agree with the SMILES they were resolved from
+    for edge in &result.edges {
+        assert_eq!(
+            result.nodes[edge.parent_idx as usize].scaffold_smiles,
+            edge.parent_smiles
+        );
+        assert_eq!(
+            result.nodes[edge.child_idx as usize].scaffold_smiles,
+            edge.child_smiles
+        );
+    }
+}
+
+#[test]
+fn test_scaffold_network_single_ring_is_trivial() {
+    let result = scaffold_network_for_smiles("c1ccccc1", &no_generics()).unwrap();
+
+    // nothing to strip: benzene is already its own scaffold
+    assert_eq!(scaffold_smiles(&result), ["c1ccccc1"]);
+    assert!(result.edges.is_empty());
+    assert_eq!(result.nodes[0].count, 1);
+    assert_eq!(result.nodes[0].mol_count, Some(1));
+}
+
+#[test]
+fn test_scaffold_network_generic_and_attachment_flags() {
+    let result = scaffold_network_for_smiles(PHENYLQUINOLINE, &Default::default()).unwrap();
+
+    let flags = result
+        .nodes
+        .iter()
+        .map(|n| (n.scaffold_smiles.as_str(), n.is_generic, n.has_attachments))
+        .collect::<Vec<_>>();
+
+    // the generic twin of a scaffold keeps that scaffold's attachment points, which is why
+    // `**1:*:*:*:*:*:1` and `*1:*:*:*:*:*:1` are both generic but differ on attachments
+    assert!(flags.contains(&("c1ccccc1", false, false)));
+    assert!(flags.contains(&("*c1ccccc1", false, true)));
+    assert!(flags.contains(&("*1:*:*:*:*:*:1", true, false)));
+    assert!(flags.contains(&("**1:*:*:*:*:*:1", true, true)));
+}
+
+#[test]
+fn test_scaffold_network_params_toggle_changes_output() {
+    let with_generics = scaffold_network_for_smiles(PHENYLQUINOLINE, &Default::default()).unwrap();
+    let without_generics = scaffold_network_for_smiles(PHENYLQUINOLINE, &no_generics()).unwrap();
+
+    assert_eq!(with_generics.nodes.len(), 9);
+    assert_eq!(without_generics.nodes.len(), 5);
+    assert!(with_generics.nodes.iter().any(|n| n.is_generic));
+    assert!(!without_generics.nodes.iter().any(|n| n.is_generic));
+}
+
+#[test]
+fn test_scaffold_network_empty_bond_breakers_never_fragment() {
+    let options = ScaffoldNetworkOptions {
+        bond_breaker_smarts: Some(vec![]),
+        ..Default::default()
+    };
+    let result = scaffold_network_for_smiles(PHENYLQUINOLINE, &options).unwrap();
+
+    assert_eq!(scaffold_smiles(&result), [PHENYLQUINOLINE]);
+}
+
+/// A molecule with no rings reduces to the empty scaffold, whose generic form is also
+/// empty, so RDKit folds them into one node with an edge pointing at itself. Anything
+/// walking these edges as a DAG needs to expect that.
+#[test]
+fn test_scaffold_network_without_rings_self_loops() {
+    let result = scaffold_network_for_smiles("CCO", &Default::default()).unwrap();
+
+    assert_eq!(scaffold_smiles(&result), ["CCO", ""]);
+    let self_loops = result
+        .edges
+        .iter()
+        .filter(|e| e.parent_idx == e.child_idx)
+        .count();
+    assert_eq!(self_loops, 1);
+}
+
+#[test]
+fn test_scaffold_network_rejects_oversized_molecule() {
+    let options = ScaffoldNetworkOptions {
+        max_atoms: Some(5),
+        ..Default::default()
+    };
+
+    let error = scaffold_network_for_smiles(PHENYLQUINOLINE, &options)
+        .unwrap_err()
+        .to_string();
+    assert_eq!(error, "molecule has 16 atoms, more than the 5 allowed");
+}
+
+#[test]
+fn test_scaffold_network_rejects_oversized_network() {
+    let options = ScaffoldNetworkOptions {
+        max_nodes: Some(2),
+        ..Default::default()
+    };
+
+    let error = scaffold_network_for_smiles(PHENYLQUINOLINE, &options)
+        .unwrap_err()
+        .to_string();
+    assert_eq!(
+        error,
+        "scaffold network has 9 nodes, more than the 2 allowed"
+    );
+}
+
+#[test]
+fn test_scaffold_network_skips_standardization_on_request() {
+    let options = ScaffoldNetworkOptions {
+        standardize: Some(false),
+        ..Default::default()
+    };
+
+    // still canonicalized on the way out, just not run through fragment_parent and
+    // tautomer canonicalization first
+    let result = scaffold_network_for_smiles("C1=CC=CC=C1", &options).unwrap();
+    assert_eq!(result.standardized_smiles.as_deref(), Some("c1ccccc1"));
+}
+
+#[test]
+fn test_scaffold_networks_for_smiles_isolates_failures() {
+    let batch = [
+        "c1ccccc1".to_string(),
+        "not-a-smiles".to_string(),
+        PHENYLQUINOLINE.to_string(),
+    ];
+    let results = scaffold_networks_for_smiles(&batch, &no_generics());
+
+    // results line up with inputs, and the bad one does not take the batch down with it
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0].error, None);
+    assert_eq!(results[0].nodes.len(), 1);
+    assert_eq!(
+        results[1].error.as_deref(),
+        Some("could not convert smiles to romol (nullptr)")
+    );
+    assert!(results[1].nodes.is_empty());
+    assert_eq!(results[2].error, None);
+    assert_eq!(results[2].nodes.len(), 5);
 }


### PR DESCRIPTION
Depends on rdkit-rs/rdkit#56.

## What

`POST /v1/scaffold_network` computes RDKit's scaffold network (`rdScaffoldNetwork`, JCIM 2020;
the HierS hierarchy conceptually) for a batch of SMILES. Where a Bemis-Murcko scaffold gives one
framework per molecule, this gives the whole hierarchy: iterative ring fragmentation producing a
graph whose nodes are canonical scaffold SMILES and whose edges point from a more specific scaffold
up to a more general one.

It is deliberately a **standalone stateless endpoint** rather than something computed at index time.
The consumer is a batch compute over a corpus, not cheminee's own search, so it touches no index and
holds no state.

- `src/search/scaffold_network.rs` — the compute, plus the `Object` payload types, next to the code
  that produces them (same shape as `StructureSearchHit` / `QuerySearchHit` in `src/search/mod.rs`)
- `src/rest_api/api/scaffold_network/` — the handler
- `src/rest_api/api/response_types.rs` — request objects and the `ApiResponse` enum

The existing static scaffold dictionary in `src/search/scaffold_search.rs` — the precomputed 2D
dictionary matched by substructure search as a tantivy accelerator — is a completely different
thing and is untouched.

## Schema

Request:

```jsonc
{
  "smiles": [{"smiles": "c1ccc(-c2ccc3ncccc3c2)cc1"}],
  "params": {                                  // all optional
    "include_generic_scaffolds": false,        // RDKit defaults these on
    "include_generic_bond_scaffolds": false,
    "include_scaffolds_with_attachments": true,
    "include_scaffolds_without_attachments": true,
    "keep_only_first_fragment": true,
    "prune_before_fragmenting": true,
    "flatten_isotopes": true,
    "flatten_chirality": true,
    "flatten_keep_largest": true,
    "collect_mol_counts": true,
    "bond_breaker_smarts": ["[!#0;R:1]-!@[!#0:2]>>[*:1]-[#0].[#0]-[*:2]"],
    "standardize": true,                       // default true
    "max_atoms": 150,
    "max_nodes": 5000
  }
}
```

Response — one entry per input, in order:

```jsonc
[{
  "smiles": "c1ccc(-c2ccc3ncccc3c2)cc1",            // as submitted
  "standardized_smiles": "c1ccc(-c2ccc3ncccc3c2)cc1",
  "nodes": [
    {"scaffold_smiles": "c1ccc(-c2ccc3ncccc3c2)cc1", "is_generic": false, "has_attachments": false, "count": 1, "mol_count": 1},
    {"scaffold_smiles": "*c1ccccc1",                 "is_generic": false, "has_attachments": true,  "count": 1, "mol_count": 1},
    {"scaffold_smiles": "c1ccccc1",                  "is_generic": false, "has_attachments": false, "count": 1, "mol_count": 1}
  ],
  "edges": [
    {"child_idx": 0, "parent_idx": 1, "child_smiles": "c1ccc(-c2ccc3ncccc3c2)cc1", "parent_smiles": "*c1ccccc1", "edge_type": "Fragment"},
    {"child_idx": 1, "parent_idx": 2, "child_smiles": "*c1ccccc1",                 "parent_smiles": "c1ccccc1",  "edge_type": "RemoveAttachment"}
  ],
  "error": null                                     // omitted when absent
}]
```

Edges carry **both** the indices and the SMILES at each end. That is redundant, and it roughly
doubles edge payload, but it means a consumer deduping scaffolds into a global graph never has to
carry the per-molecule node array alongside. Happy to drop the SMILES if the payload size matters
more than the convenience.

`edge_type` is RDKit's own label: `Fragment`, `Generic`, `GenericBond`, `RemoveAttachment` or
`Initialize`.

## Failure handling

A bad or pathological input returns **200 with that item's `error` set**, never a 500 and never a
panic. The 500 variant exists only for the compute task itself dying.

The C++ FFI crash-safety story has three parts:

1. Parse and sanitize failures come back through `Result` from the rdkit crate, never as an unwind.
2. **RDKit runs to completion once started and cannot be interrupted**, so a time-based guard is not
   available. The real protection is refusing oversized input up front: `max_atoms` defaults to 150,
   comfortably above drug-like. `max_nodes` (default 5000) is a backstop on response size, checked
   after the fact.
3. Node flags are derived from the edges RDKit already labelled rather than by re-parsing each
   scaffold SMILES. That is not only cheaper — I tried the re-parsing approach first and handing a
   generic SMILES like `*1:*:*:*:*:*:1` back to RDKit trips an `Invar::Invariant` inside the
   property cache, which reaches a `noexcept` boundary and **aborts the process** rather than
   raising. That would take the whole server down.

Fragmenting runs on the blocking pool via `spawn_blocking` with rayon inside, so a large batch does
not tie up an async worker (same shape as `bulk_index`).

## Two things the consumer needs to know

Both are pinned by tests.

1. **A ring-free molecule produces a self-loop.** `CCO` reduces to the empty scaffold `""`, whose
   generic twin is also `""`, so RDKit folds them into one node with an edge pointing at itself.
   Anything walking these edges as a DAG has to expect that, and will probably want to drop the
   empty-SMILES node outright.
2. **`bond_breaker_smarts: []` disables fragmentation entirely** and every network comes back as a
   single node. Omitting the field keeps RDKit's default breaker, which is what you want.

Also worth flagging: `standardize` defaults to **true**, matching `/v1/standardize`. Tautomer
canonicalization dominates the cost of the whole call, so a batch job over already-canonical SMILES
should send `"standardize": false`.

## Version pin

`rdkit` currently points at the PR branch so this can be reviewed and tested:

```toml
rdkit = { git = "https://github.com/rdkit-rs/rdkit", branch = "scaffold_network_generator" }
```

**Before merge** this goes back to `rdkit = { version = "0.4.13" }`, once rdkit-rs/rdkit#56 is
merged and released. There is a `TODO` on the line. cheminee's own version is left alone.

## Reaching the Ruby client — needs a tag

`.github/workflows/generate_ruby_gem.yaml` runs **only on a tag push**. There is no PR-time gate
comparing the spec to the gem, so merging this does not move `assaydepot/cheminee-ruby` at all.

After merge, **push a tag** (next would be `0.1.53`) to run the generator, commit to
`assaydepot/cheminee-ruby` and push the gem to RubyGems. Only then does this appear as:

- `Cheminee::DefaultApi#v1_scaffold_network_post`
- `Cheminee::ScaffoldNetworkRequest`, `Cheminee::ScaffoldNetworkParams`,
  `Cheminee::ScaffoldNetworkResult`, `Cheminee::ScaffoldNetworkNode`,
  `Cheminee::ScaffoldNetworkEdge`, `Cheminee::ScaffoldNetworkResponseError`

Method and model names confirmed against the naming the existing gem already uses
(`v1_convert_mol_block_to_smiles_post` etc). No hand-editing of the generated gem.

## Test evidence

Run against RDKit 2024_09_1 + TensorFlow 2.15.1 on Ubuntu 22.04, matching what
`test_suite.yml` installs, since neither is available on the dev host.

```
cargo test
  tests/api_tests.rs ................ 22 passed   (17 existing + 5 new)
  tests/search_tests.rs ............. 19 passed   (8 existing + 11 new)
  tests/cpd_processing_tests.rs ..... 15 passed
  tests/cli_tests.rs ................  2 passed
  tests/structure_matching_tests.rs .  3 passed
  tests/encoder_tests.rs ............  1 passed
  tests/index_management_tests.rs ...  1 passed
  tests/user_data_indexing_tests.rs .  1 passed
  unittests src/lib.rs ..............  1 passed
  0 failed
```

New coverage: multi-ring molecule producing a multi-node hierarchy with parent/child edges asserted
by SMILES rather than by index; single ring giving a trivial one-node network; bad SMILES giving a
per-item error inside a 200 while its neighbour in the batch still succeeds; a params toggle
changing the output (9 nodes with generics, 5 without); the generic/attachment flags on all four
combinations; both limits; the empty-bond-breaker case; the ring-free self-loop; and
`standardize: false`.

```
cargo fmt --check   # clean
cargo clippy        # no new warnings (3 pre-existing remain in bulk_delete.rs x2 and
                    # compound_processing.rs — untouched)
```

Spec regenerated with `cheminee rest-api-server spec -o openapi.json` and checked: `/v1/scaffold_network`
is present with 200 and 500 responses, and all six models resolve. `openapi.json` is gitignored, so
nothing is committed for it — CI regenerates at tag time.

## Prior art

This binds RDKit's `rdScaffoldNetwork`; it is not an implementation of HierS. The two are in the
same family but differ: HierS (Wilkens, Janes & Su, "HierS: hierarchical scaffold clustering using
topological chemical graphs", *J. Med. Chem.* 2005, 48(9), 3182-93,
[doi:10.1021/jm049032d](https://doi.org/10.1021/jm049032d), PMID 15857124) recursively enumerates
ring-delimited substructures, where RDKit applies a bond breaking reaction and additionally emits
`Generic`, `GenericBond` and `RemoveAttachment` scaffolds that HierS has no equivalent of.

HierS is cited in the module docs as the prior art that established this class of hierarchy, and
labelled as such rather than as the implemented algorithm. Worth noting that RDKit's
`Code/GraphMol/ScaffoldNetwork/` sources carry no citation of their own, so there is no primary
reference to point at for the exact algorithm.

